### PR TITLE
Remove the SetSuccess stage (and the need for it)

### DIFF
--- a/examples/build_api/sequence.py
+++ b/examples/build_api/sequence.py
@@ -44,7 +44,6 @@ onnx_sequence = stage.Sequence(
         export.ExportPytorchModel(),
         export.OptimizeOnnxModel(),
         # export.ConvertOnnxToFp16(),  #<-- This is the step we want to skip
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )

--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
@@ -27,7 +27,6 @@ combined_example_sequence = Sequence(
     stages=[
         export.ExportPlaceholder(),
         CombinedExampleStage(),
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )

--- a/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
+++ b/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
@@ -43,7 +43,6 @@ example_sequence = Sequence(
     stages=[
         export.ExportPlaceholder(),
         ExampleStage(),
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -620,23 +620,3 @@ class ConvertOnnxToFp16(stage.Stage):
             raise exp.StageError(msg)
 
         return state
-
-
-class SuccessStage(stage.Stage):
-    """
-    Stage that sets state.build_status = build.Status.SUCCESSFUL_BUILD,
-    indicating that the build sequence has completed all of the requested build stages.
-    """
-
-    def __init__(self):
-        super().__init__(
-            unique_name="set_success",
-            monitor_message="Finishing up",
-        )
-
-    def fire(self, state: build.State):
-        state.build_status = build.Status.SUCCESSFUL_BUILD
-
-        state.results = copy.deepcopy(state.intermediate_results)
-
-        return state

--- a/src/turnkeyml/build/sequences.py
+++ b/src/turnkeyml/build/sequences.py
@@ -9,7 +9,6 @@ optimize_fp16 = stage.Sequence(
         export.ExportPlaceholder(),
         export.OptimizeOnnxModel(),
         export.ConvertOnnxToFp16(),
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )
@@ -20,7 +19,6 @@ optimize_fp32 = stage.Sequence(
     [
         export.ExportPlaceholder(),
         export.OptimizeOnnxModel(),
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )
@@ -30,7 +28,6 @@ onnx_fp32 = stage.Sequence(
     "Base Sequence",
     [
         export.ExportPlaceholder(),
-        export.SuccessStage(),
     ],
     enable_model_validation=True,
 )

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -2,6 +2,7 @@ import abc
 import sys
 import time
 import os
+import copy
 from typing import List, Tuple
 from multiprocessing import Process
 import psutil
@@ -108,8 +109,7 @@ class Stage(abc.ABC):
 
         # Set the build status to BUILD_RUNNING to indicate that a Stage
         # started running. This allows us to test whether the Stage exited
-        # unexpectedly, before it was able to set FAILED_BUILD, SUCCESSFUL_BUILD,
-        # or PARTIAL_BUILD
+        # unexpectedly, before it was able to set FAILED_BUILD
         state.build_status = build.Status.BUILD_RUNNING
 
         self.logfile_path = os.path.join(
@@ -137,11 +137,16 @@ class Stage(abc.ABC):
         else:
             self.status_line(successful=True, verbosity=state.monitor)
 
-            # Set the build status PARTIAL_BUILD, indicating that the stage
-            # ran successfully, unless the stage set SUCCESSFUL_BUILD, in which
-            # case leave the build status alone.
-            if state.build_status != build.Status.SUCCESSFUL_BUILD:
-                state.build_status = build.Status.PARTIAL_BUILD
+            # Stages should not set build.Status.SUCCESSFUL_BUILD, as that is
+            # reserved for Sequence.launch()
+            if state.build_status == build.Status.SUCCESSFUL_BUILD:
+                raise exp.StageError(
+                    "TurnkeyML Stages are not allowed to set "
+                    "`state.build_status == build.Status.SUCCESSFUL_BUILD`, "
+                    "however that has happened. If you are a plugin developer, "
+                    "do not do this. If you are a user, please file an issue at "
+                    "https://github.com/onnx/turnkeyml/issues."
+                )
 
         finally:
             if state.monitor:
@@ -314,6 +319,10 @@ class Sequence(Stage):
 
         else:
             state.current_build_stage = None
+            state.build_status = build.Status.SUCCESSFUL_BUILD
+
+            state.results = copy.deepcopy(state.intermediate_results)
+
             return state
 
     def status_line(self, successful, verbosity):

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -321,6 +321,10 @@ class Sequence(Stage):
             state.current_build_stage = None
             state.build_status = build.Status.SUCCESSFUL_BUILD
 
+            # We use a deepcopy here because the Stage framework supports
+            # intermediate_results of any type, including model objects in memory.
+            # The deepcopy ensures that we are providing a result that users
+            # are free to take any action with.
             state.results = copy.deepcopy(state.intermediate_results)
 
             return state

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -232,38 +232,6 @@ def scriptmodule_functional_check():
     return state.build_status == build.Status.SUCCESSFUL_BUILD
 
 
-def full_compile_individual_stages():
-    build_name = "full_compile_individual_stages"
-    build_model(
-        pytorch_model,
-        inputs,
-        build_name=build_name,
-        rebuild="always",
-        monitor=False,
-        sequence=stage.Sequence(
-            "ExportPytorchModel_seq", "", [export.ExportPytorchModel()]
-        ),
-        cache_dir=cache_location,
-    )
-    build_model(
-        build_name=build_name,
-        sequence=stage.Sequence("OptimizeModel_seq", "", [export.OptimizeOnnxModel()]),
-        cache_dir=cache_location,
-    )
-    build_model(
-        build_name=build_name,
-        sequence=stage.Sequence("Fp16Conversion_seq", "", [export.ConvertOnnxToFp16()]),
-        cache_dir=cache_location,
-    )
-    state = build_model(
-        build_name=build_name,
-        sequence=stage.Sequence("SuccessStage_seq", "", [export.SuccessStage()]),
-        cache_dir=cache_location,
-    )
-
-    return state.build_status == build.Status.SUCCESSFUL_BUILD
-
-
 def custom_stage():
     build_name = "custom_stage"
 
@@ -299,7 +267,6 @@ def custom_stage():
             export.ExportPytorchModel(),
             export.OptimizeOnnxModel(),
             my_custom_stage,
-            export.SuccessStage(),
         ],
     )
 
@@ -536,9 +503,6 @@ class Testing(unittest.TestCase):
 
     def test_007_full_compilation_hummingbird_xgb(self):
         assert full_compilation_hummingbird_xgb()
-
-    def test_008_full_compile_individual_stages(self):
-        assert full_compile_individual_stages()
 
     def test_009_custom_stage(self):
         assert custom_stage()


### PR DESCRIPTION
Addresses #36 by automatically setting `state.build_status == build.Status.SUCCESSFUL_BUILD` at the end of `Sequence.launch()`

This PR also removes some code and one test that related to a long-deprecated incremental compilation feature.