### PR TITLE
Cleaner report on stages completed

### DIFF
--- a/src/turnkeyml/cli/report.py
+++ b/src/turnkeyml/cli/report.py
@@ -81,8 +81,17 @@ def summary_spreadsheets(args) -> None:
                             # Break each value in "completed build stages" into its own column
                             # to make analysis easier
                             if key == fs.Keys.COMPLETED_BUILD_STAGES:
-                                for subkey, subvalue in value.items():
-                                    evaluation_stats[subkey] = subvalue
+                                for stage in build[fs.Keys.ALL_BUILD_STAGES]:
+                                    column_name = f"stage_duration-{stage}"
+                                    if stage in build[fs.Keys.COMPLETED_BUILD_STAGES]:
+                                        evaluation_stats[column_name] = build[
+                                            fs.Keys.COMPLETED_BUILD_STAGES
+                                        ][stage]
+                                    else:
+                                        evaluation_stats[column_name] = "INCOMPLETE"
+
+                                # Do not add the raw version of COMPLETED_BUILD_STAGES to the report
+                                continue
 
                             # If a build or benchmark is still marked as "running" at
                             # reporting time, it


### PR DESCRIPTION
Closes https://github.com/onnx/turnkeyml/issues/35

# Description

This PR:
* Removes `stages_completed` from the report (redundant information)
* Adds "INCOMPLETE" for stages in the report that have not been completed
* Appends "stage_duration" to all columns in the report that correspond to the duration of specific stages

Note: Although this PR attempts to provide the completed stages in order in the report, this order can't be guaranteed, as different builds may have a different order of stages.

## Sample Report Snippet 

![image](https://github.com/onnx/turnkeyml/assets/9607530/e70e7cfe-c942-44e4-9c4b-2e064aa53c34)
