### PR TITLE
Organize the turnkey benchmark help menu

### DIFF
--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -113,7 +113,8 @@ def main():
     )
 
     toolchain_select_group = benchmark_parser.add_argument_group(
-        "Select which phase(s) of the toolchain to run (default is to run analyze, build, and benchmark)"
+        "Select which phase(s) of the toolchain to run "
+        "(default is to run analyze, build, and benchmark)"
     )
 
     toolchain_select_group.add_argument(


### PR DESCRIPTION
This is a maintenance cleanup PR.

Closes #73 by organizing each option in `turnkey benchmark -h` into a section (aka argparse argument group).

Note: it only looks like a ton of changes because I reordered the code to neatly fit into the new sections. I didn't add or remove any arguments.

## Demo

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml$ turnkey benchmark -h
```

```
usage: turnkey benchmark [-h] [-a] [-b] [--labels [LABELS [LABELS ...]]] [--script-args SCRIPT_ARGS]
                         [--max-depth MAX_DEPTH] [--device {nvidia,x86}] [--runtime {ort,trt,torch-eager,torch-compiled}]
                         [-d CACHE_DIR] [--lean-cache] [--sequence {optimize-fp16,optimize-fp32,onnx-fp32}]
                         [--rebuild {if_needed,always,never}] [--onnx-opset ONNX_OPSET] [--iterations ITERATIONS]
                         [--rt-args [RT_ARGS [RT_ARGS ...]]] [--use-slurm | --process-isolation] [--timeout TIMEOUT]
                         input_files [input_files ...]

Analyze, build, and then benchmark the model(s) within input file(s).

positional arguments:
  input_files           One or more script (.py), ONNX (.onnx), or input list (.txt) files to be benchmarked

optional arguments:
  -h, --help            show this help message and exit

Select which phase(s) of the toolchain to run (default is to run analyze, build, and benchmark):
  -a, --analyze-only    Stop this command after the analyze phase
  -b, --build-only      Stop this command after the analyze and build phases

Options that specifically apply to the `analyze` phase of the toolflow:
  --labels [LABELS [LABELS ...]]
                        Only benchmark the scripts that have the provided labels
  --script-args SCRIPT_ARGS
                        Arguments to pass into the target script(s)
  --max-depth MAX_DEPTH
                        Maximum depth to analyze within the model structure of the target script(s)

Options that apply to both the `build` and `benchmark` phases of the toolflow:
  --device {nvidia,x86}
                        Type of hardware device to be used for the benchmark (defaults to "x86")
  --runtime {ort,trt,torch-eager,torch-compiled}
                        Software runtime that will be used to collect the benchmark. Must be compatible with the selected
                        device. Automatically selects a sequence if `--sequence` is not used.If this argument is not set,
                        the default runtime of the selected device will be used.
  -d CACHE_DIR, --cache-dir CACHE_DIR
                        Build cache directory where the resulting build directories will be stored (defaults to
                        /home/jefowers/.cache/turnkey)
  --lean-cache          Delete all build artifacts except for log files when the command completes

Options that apply specifically to the `build` phase of the toolflow:
  --sequence {optimize-fp16,optimize-fp32,onnx-fp32}
                        Name of a build sequence that will define the model-to-model transformations, used to build the
                        models. Each runtime has a default sequence that it uses.
  --rebuild {if_needed,always,never}
                        Sets the cache rebuild policy (defaults to if_needed)
  --onnx-opset ONNX_OPSET
                        ONNX opset used when creating ONNX files (default=14). Not applicable when input model is already a
                        .onnx file.

Options that apply specifically to the `benchmark` phase of the toolflow:
  --iterations ITERATIONS
                        Number of execution iterations of the model to capture the benchmarking performance (e.g., mean
                        latency)
  --rt-args [RT_ARGS [RT_ARGS ...]]
                        Optional arguments provided to the runtime being used

Options that apply to all toolflows:
  --use-slurm           Execute on Slurm instead of using local compute resources
  --process-isolation   Isolate evaluating each input into a separate process
  --timeout TIMEOUT     Build timeout, in seconds, after which a build will be canceled (default=3600). Only applies when
                        --process-isolation or --use-slurm is also used.
```