### PR TITLE
Simplify the help on incorrect positional arg

### DIFF
--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -21,11 +21,6 @@ class MyParser(argparse.ArgumentParser):
         self.print_help()
         sys.exit(2)
 
-    def print_cache_help(self):
-        print("Error: a cache command is required")
-        self.print_help()
-        sys.exit(2)
-
 
 def print_version(_):
     """
@@ -90,11 +85,11 @@ def main():
     # Parser for the "benchmark" command
     #######################################
 
-    def check_extension(choices, file_name):
+    def check_extension(choices, file_name, error_func):
         _, extension = os.path.splitext(file_name.split("::")[0])
         if extension[1:].lower() not in choices:
-            raise exceptions.ArgError(
-                f"input_files must end with .py, .onnx, or .txt (got '{file_name}')"
+            error_func(
+                f"input_files must end with .py, .onnx, or .txt (got '{file_name}')\n"
             )
         return file_name
 
@@ -107,7 +102,9 @@ def main():
         "input_files",
         nargs="+",
         help="One or more script (.py), ONNX (.onnx), or input list (.txt) files to be benchmarked",
-        type=lambda file: check_extension(("py", "onnx", "txt"), file),
+        type=lambda file: check_extension(
+            ("py", "onnx", "txt"), file, benchmark_parser.error
+        ),
     )
 
     slurm_or_processes_group = benchmark_parser.add_mutually_exclusive_group()
@@ -491,7 +488,7 @@ def main():
 
                 if close_matches:
                     raise exceptions.ArgError(
-                        f"Unexpected positional argument `turnkey {first_arg}`. "
+                        f"Unexpected command `turnkey {first_arg}`. "
                         f"Did you mean `turnkey {close_matches[0]}`?"
                     )
 

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -472,17 +472,20 @@ def main():
     # on a target script. If the user doesn't provide a command,
     # we alter argv to insert the command for them.
 
+    # Special characters that indicate a string is a filename, not a command
+    file_chars = [".", "/", "\\", "*"]
+
     if len(sys.argv) > 1:
         first_arg = sys.argv[1]
         if first_arg not in subparsers.choices.keys() and "-h" not in first_arg:
-            if "." in first_arg:
+            if any(char_to_check in first_arg for char_to_check in file_chars):
                 # User has provided a file as the first positional arg
                 sys.argv.insert(1, "benchmark")
             else:
                 # User has provided a command as the first positional arg
                 # Check how close we are from each of the valid options
                 # NOTE: if we are not close to a valid option, we will let
-                # argparse handle the error
+                # argparse detect and raise the error
                 valid_options = list(subparsers.choices.keys())
                 close_matches = get_close_matches(first_arg, valid_options)
 

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -476,22 +476,21 @@ def main():
         first_arg = sys.argv[1]
         if first_arg not in subparsers.choices.keys() and "-h" not in first_arg:
             if "." in first_arg:
+                # User has provided a file as the first positional arg
                 sys.argv.insert(1, "benchmark")
             else:
+                # User has provided a command as the first positional arg
                 # Check how close we are from each of the valid options
+                # NOTE: if we are not close to a valid option, we will let
+                # argparse handle the error
                 valid_options = list(subparsers.choices.keys())
                 close_matches = get_close_matches(first_arg, valid_options)
 
-                error_msg = f"Unexpected positional argument `turnkey {first_arg}`. "
                 if close_matches:
-                    error_msg += f"Did you mean `turnkey {close_matches[0]}`?"
-                else:
-                    error_msg += (
-                        "The first positional argument must either be "
-                        "an input file with the .py or .onnx file extension or "
-                        f"one of the following commands: {valid_options}."
+                    raise exceptions.ArgError(
+                        f"Unexpected positional argument `turnkey {first_arg}`. "
+                        f"Did you mean `turnkey {close_matches[0]}`?"
                     )
-                raise exceptions.ArgError(error_msg)
 
     args = parser.parse_args()
 

--- a/test/cli.py
+++ b/test/cli.py
@@ -722,7 +722,7 @@ class Testing(unittest.TestCase):
 
     def test_017_invalid_file_type(self):
         # Ensure that we get an error when running turnkey with invalid input_files
-        with self.assertRaises(exceptions.ArgError):
+        with self.assertRaises(SystemExit):
             testargs = ["turnkey", "gobbledegook"]
             with patch.object(sys, "argv", flatten(testargs)):
                 turnkeycli()


### PR DESCRIPTION
This is a bug fix PR.

Closes #72 by simplifying the error processing code. See #72 for an example of how thev overloaded error message would always look before.

Before: on generic errors, provide help that was relevant to both invalid command and invalid file

Now: on generic errors, let argparse decide an appropriate and specific error message for commands and files, respectively. 

# Demos

## Invalid Command (Close to real command)

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey banchmerk linear.py
```

```

Error: Unexpected positional argument `turnkey banchmerk`. Did you mean `turnkey benchmark`?

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████


Traceback (most recent call last):
  File "/home/jefowers/miniconda3/envs/tkml/bin/turnkey", line 8, in <module>
    sys.exit(turnkeycli())
  File "/home/jefowers/turnkeyml/src/turnkeyml/cli/cli.py", line 490, in main
    raise exceptions.ArgError(
turnkeyml.common.exceptions.ArgError: Unexpected positional argument `turnkey banchmerk`. Did you mean `turnkey benchmark`?
```

## Invalid Command (Not Close)

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey build linear.py
```

```
error: argument COMMAND: invalid choice: 'build' (choose from 'benchmark', 'cache', 'models', 'version')
usage: turnkey [-h] COMMAND ...

TurnkeyML benchmarking command line interface

optional arguments:
  -h, --help  show this help message and exit

command:
  COMMAND     Choose one of the following commands:
    benchmark
              Benchmark the performance of one or more models
    cache     Commands for managing the build cache
    models    Commands for managing the models
    version   Print the package version number
```

## Invalid File Input (Explicit benchmark command)

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey benchmark lanier.py
```

```
Error: ['lanier.py'] do not exist, please verify if the file(s) exists.

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████


Traceback (most recent call last):
  File "/home/jefowers/miniconda3/envs/tkml/bin/turnkey", line 8, in <module>
    sys.exit(turnkeycli())
  File "/home/jefowers/turnkeyml/src/turnkeyml/cli/cli.py", line 500, in main
    args.func(args)
  File "/home/jefowers/turnkeyml/src/turnkeyml/cli/cli.py", line 64, in benchmark_command
    benchmark_files(**api_args)
  File "/home/jefowers/turnkeyml/src/turnkeyml/files_api.py", line 133, in benchmark_files
    raise exceptions.ArgError(
turnkeyml.common.exceptions.ArgError: ['lanier.py'] do not exist, please verify if the file(s) exists.
```

## Invalid File Input (Implied benchmark command)

Same as the prior demo (as it should be)

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey lanier.py
```
 
```
Error: ['lanier.py'] do not exist, please verify if the file(s) exists.

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████


Traceback (most recent call last):
  File "/home/jefowers/miniconda3/envs/tkml/bin/turnkey", line 8, in <module>
    sys.exit(turnkeycli())
  File "/home/jefowers/turnkeyml/src/turnkeyml/cli/cli.py", line 500, in main
    args.func(args)
  File "/home/jefowers/turnkeyml/src/turnkeyml/cli/cli.py", line 64, in benchmark_command
    benchmark_files(**api_args)
  File "/home/jefowers/turnkeyml/src/turnkeyml/files_api.py", line 133, in benchmark_files
    raise exceptions.ArgError(
turnkeyml.common.exceptions.ArgError: ['lanier.py'] do not exist, please verify if the file(s) exists.
```

## Invalid File Extension

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey benchmark bob.po
```

Before: would throw a fail whale and a stack trace.

Now: stardard argparse exit:

```
error: input_files must end with .py, .onnx, or .txt (got 'bob.po')

usage: turnkey benchmark [-h] [--use-slurm | --process-isolation]
                         [--lean-cache] [-d CACHE_DIR]
                         [--labels [LABELS [LABELS ...]]]
                         [--sequence {optimize-fp16,optimize-fp32,onnx-fp32}]
                         [--rebuild {if_needed,always,never}]
                         [--device {nvidia,x86}]
                         [--runtime {ort,trt,torch-eager,torch-compiled}]
                         [--iterations ITERATIONS] [--analyze-only] [-b]
                         [--script-args SCRIPT_ARGS] [--max-depth MAX_DEPTH]
                         [--onnx-opset ONNX_OPSET] [--timeout TIMEOUT]
                         [--rt-args [RT_ARGS [RT_ARGS ...]]]
                         input_files [input_files ...]
```