### PR TITLE
Less verbose cli errors

### DIFF
--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -17,8 +17,9 @@ from turnkeyml.cli.spawn import DEFAULT_TIMEOUT_SECONDS
 
 class MyParser(argparse.ArgumentParser):
     def error(self, message):
-        sys.stderr.write("error: %s\n" % message)
-        self.print_help()
+        sys.stderr.write(f"error: {message}\n\n")
+        sys.stderr.write(f"Run '{self.prog} --help' for more information\n\n")
+        self.print_usage(sys.stderr)
         sys.exit(2)
 
 


### PR DESCRIPTION
Closes #76 by printing only usage and a hint, instead of the full help page, on CLI arg errors.

# Demos

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey cache stats --blah
```
```
error: the following arguments are required: build_name

Run 'turnkey cache stats --help' for more information

usage: turnkey cache stats [-h] [-d CACHE_DIR] build_name
```

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey cache blah
```

```
error: argument cache_cmd: invalid choice: 'blah' (choose from 'report', 'list', 'stats', 'delete', 'clean', 'location')

Run 'turnkey cache --help' for more information

usage: turnkey cache [-h] {report,list,stats,delete,clean,location} ...
```

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey golboddy  report
```

```
error: argument COMMAND: invalid choice: 'golboddy' (choose from 'benchmark', 'cache', 'models', 'version')

Run 'turnkey --help' for more information

usage: turnkey [-h] COMMAND ...
```

```
(tkml) jefowers@XSJ-JEFOWERS-L1:~/turnkeyml/models/selftest$ turnkey bob.po
```

```
error: input_files must end with .py, .onnx, or .txt (got 'bob.po')

Run 'turnkey benchmark --help' for more information

usage: turnkey benchmark [-h] [-a] [-b] [--labels [LABELS [LABELS ...]]]
                         [--script-args SCRIPT_ARGS] [--max-depth MAX_DEPTH]
                         [--device {nvidia,x86}]
                         [--runtime {ort,trt,torch-eager,torch-compiled}]
                         [-d CACHE_DIR] [--lean-cache]
                         [--sequence {optimize-fp16,optimize-fp32,onnx-fp32}]
                         [--rebuild {if_needed,always,never}]
                         [--onnx-opset ONNX_OPSET] [--iterations ITERATIONS]
                         [--rt-args [RT_ARGS [RT_ARGS ...]]]
                         [--use-slurm | --process-isolation]
                         [--timeout TIMEOUT]
                         input_files [input_files ...]
```