### PR TITLE
Check torch onnx export validity

### DIFF
--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -6,11 +6,11 @@ import sys
 import copy
 from typing import Union
 import torch
+import torch.onnx.verification
 import numpy as np
 import onnxruntime
 import onnxmltools
 import onnx
-import torch.onnx.verification
 import turnkeyml.build.stage as stage
 import turnkeyml.common.exceptions as exp
 import turnkeyml.common.build as build
@@ -286,11 +286,12 @@ class ExportPytorchModel(stage.Stage):
 
         # Verify if the exported model matches the input torch model
         try:
-            # The `torch.onnx.verification.find_mismatch()` the input arguments to the
+            # The `torch.onnx.verification.find_mismatch()` takes input arguments to the
             # model as `input_args (Tuple[Any, ...])`
-            export_verification = torch.onnx.verification.find_mismatch(state.model,
-                                                                        (first_input,),
-                                                                        opset_version=state.config.onnx_opset)
+            export_verification = torch.onnx.verification.find_mismatch(
+                state.model,
+                tuple(state.inputs.values()),
+                opset_version=state.config.onnx_opset)
             is_export_valid = not export_verification.has_mismatch()
         except Exception: # pylint: disable=broad-except
             is_export_valid = "Unverified"

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -292,12 +292,26 @@ class ExportPytorchModel(stage.Stage):
                 state.model,
                 tuple(state.inputs.values()),
                 opset_version=state.config.onnx_opset)
-            is_export_valid = not export_verification.has_mismatch()
-        except Exception: # pylint: disable=broad-except
+            
+            # `export_verification.has_mismatch()` returns True if a mismatch is found and
+            # False otherwise. If no mismatch is found,# `is_export_valid` is set to "Valid",
+            # indicating successful verification.
+            # If a mismatch is found, `is_export_valid` is set to "Invalid", indicating
+            # the verification failed.
+            if not export_verification.has_mismatch():
+                is_export_valid = "Valid"
+            else:
+                is_export_valid = "Invalid"
+        
+        # The except block catches any type of exception that might occur during the
+        # verification process. If any exception occurs,`is_export_valid` is set to 
+        # "Unverified", indicating that the verification process could not be completed,
+        # and therefore the model's export status is unverified.
+        except Exception:  # pylint: disable=broad-except
             is_export_valid = "Unverified"
 
         stats.save_model_eval_stat(
-                fs.Keys.TORCH_EXPORT_VERIFIED,
+                fs.Keys.TORCH_ONNX_EXPORT_VALIDITY,
                 is_export_valid,
         )
 

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -292,23 +292,23 @@ class ExportPytorchModel(stage.Stage):
                 state.model,
                 tuple(state.inputs.values()),
                 opset_version=state.config.onnx_opset)
-            
+
             # `export_verification.has_mismatch()` returns True if a mismatch is found and
             # False otherwise. If no mismatch is found,# `is_export_valid` is set to "Valid",
             # indicating successful verification.
             # If a mismatch is found, `is_export_valid` is set to "Invalid", indicating
             # the verification failed.
             if not export_verification.has_mismatch():
-                is_export_valid = "Valid"
+                is_export_valid = "valid"
             else:
-                is_export_valid = "Invalid"
-        
+                is_export_valid = "invalid"
+
         # The except block catches any type of exception that might occur during the
-        # verification process. If any exception occurs,`is_export_valid` is set to 
+        # verification process. If any exception occurs,`is_export_valid` is set to
         # "Unverified", indicating that the verification process could not be completed,
         # and therefore the model's export status is unverified.
         except Exception:  # pylint: disable=broad-except
-            is_export_valid = "Unverified"
+            is_export_valid = "unverified"
 
         stats.save_model_eval_stat(
                 fs.Keys.TORCH_ONNX_EXPORT_VALIDITY,

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -360,7 +360,7 @@ class Keys:
     BENCHMARK_STATUS = "benchmark_status"
     # Indicates the match between the TorchScript IR graph and
     # the exported onnx model (verified with torch.onnx.verification)
-    TORCH_EXPORT_VERIFIED = "torch_export_verified"
+    TORCH_ONNX_EXPORT_VALIDITY = "torch_export_validity"
 
 class FunctionStatus:
     RUNNING = "running"

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -358,7 +358,9 @@ class Keys:
     BUILD_STATUS = "build_status"
     # Indicates status of the most recent benchmark tool run: FunctionStatus
     BENCHMARK_STATUS = "benchmark_status"
-
+    # Indicates the match between the TorchScript IR graph and
+    # the exported onnx model (verified with torch.onnx.verification)
+    TORCH_EXPORT_VERIFIED = "torch_export_verified"
 
 class FunctionStatus:
     RUNNING = "running"


### PR DESCRIPTION
This PR adds the ability to verify if the torch onnx exporter broke the model during export.
We dont throw an error upon failure of validity check, rather capture this info in the `turnkey_stats.yaml` file as shown below.

![image](https://github.com/onnx/turnkeyml/assets/12814146/4cb275cf-d9d1-4e1b-85be-b68c4238d46b)
