### PR TITLE
Only add evaluation stats to the report once

### DIFF
--- a/src/turnkeyml/cli/report.py
+++ b/src/turnkeyml/cli/report.py
@@ -108,17 +108,17 @@ def summary_spreadsheets(args) -> None:
                 if header not in column_headers:
                     column_headers.append(header)
 
-        # Add each build to the report
-        for evaluation_stats in all_evaluation_stats:
-            # Start with a dictionary where all of the values are "-". If a build
-            # has a value for each key we will fill it in, and otherwise the "-"
-            # will indicate that no value was available
-            result = {k: "-" for k in column_headers}
+    # Add each build to the report
+    for evaluation_stats in all_evaluation_stats:
+        # Start with a dictionary where all of the values are "-". If a build
+        # has a value for each key we will fill it in, and otherwise the "-"
+        # will indicate that no value was available
+        result = {k: "-" for k in column_headers}
 
-            for key in column_headers:
-                result[key] = _good_get(evaluation_stats, key)
+        for key in column_headers:
+            result[key] = _good_get(evaluation_stats, key)
 
-            report.append(result)
+        report.append(result)
 
     # Populate results spreadsheet
     with open(report_path, "w", newline="", encoding="utf8") as spreadsheet:


### PR DESCRIPTION
Closes #81 

`all_evaluation_stats` is a list that aggregates results across all caches, such that we can write them to the report CSV.

The implementation has a bug where we were adding `all_evaluation_stats` to `report` in the loop that traverses the caches, meaning results from cache N of T would be written to the CSV T-N times. Which would make the report insanely large if you have many caches. 