### PR TITLE
Fix CI and enable TKML to work with torch >= 2.2.0

### DIFF
--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -537,6 +537,14 @@ def explore_frame(
                 tracer_args.models_found[
                     local_var.turnkey_hash
                 ].model_type = build.ModelType.PYTORCH_COMPILED
+
+            # Starting in version 2.2.0, torch dynamo added wrappers to callbacks
+            # while tracing frames, which conflicts with TurnkeML's analysis. Here,
+            # we supress errors caused by those callback wrappers and only raise an
+            # error if the compiled model actually tries to execute within TurnkeyML.
+            torch._dynamo.config.suppress_errors = True
+
+
             return
 
         if model_type == build.ModelType.PYTORCH:

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -544,7 +544,6 @@ def explore_frame(
             # error if the compiled model actually tries to execute within TurnkeyML.
             torch._dynamo.config.suppress_errors = True
 
-
             return
 
         if model_type == build.ModelType.PYTORCH:

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -542,7 +542,7 @@ def explore_frame(
             # while tracing frames, which conflicts with TurnkeML's analysis. Here,
             # we supress errors caused by those callback wrappers and only raise an
             # error if the compiled model actually tries to execute within TurnkeyML.
-            torch._dynamo.config.suppress_errors = True
+            torch._dynamo.config.suppress_errors = True # pylint: disable=protected-access
 
             return
 

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -542,7 +542,10 @@ def explore_frame(
             # while tracing frames, which conflicts with TurnkeML's analysis. Here,
             # we supress errors caused by those callback wrappers and only raise an
             # error if the compiled model actually tries to execute within TurnkeyML.
-            torch._dynamo.config.suppress_errors = True # pylint: disable=protected-access
+            td = torch._dynamo # pylint: disable=protected-access
+            td.config.suppress_errors = True
+            if hasattr(td.eval_frame, "guarded_backend_cache"):
+                td.eval_frame.guarded_backend_cache.skip_backend_check_for_run_only_mode = True
 
             return
 


### PR DESCRIPTION
Closes https://github.com/onnx/turnkeyml/issues/98

# Issue

Torch recently released version 2.2.0, which broke TKML's CI pipeline.

The issue is caused by torch dynamo instrumenting callback functions, which conflicts with TKML's analysis and causes it to crash before TKML can report that only models in eager mode are supported.

# Torch versions supported

This PR has been manually tested with both `torch 2.1.2` and `torch 2.2.0`. As a result, we can continue to assume that tkml works with the latest versions of `torch`.