### PR TITLE
Handling what happens when process isolation jobs crash

### DIFF
--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -180,6 +180,11 @@ def explore_invocation(
     )
     invocation_info.stats = stats
 
+    # Print the evaluation ID so that we can access it in case this process is killed
+    print(
+        f"Capturing statistics in turnkey_stats.yaml under evaluation ID: {evaluation_id}"
+    )
+
     # Stats that apply to the model, regardless of build
     stats.save_model_stat(
         fs.Keys.HASH,
@@ -534,18 +539,20 @@ def explore_frame(
             # A previously-found model might have been compiled
             # Update that information if needed
             if model_type == build.ModelType.PYTORCH_COMPILED:
-                tracer_args.models_found[
-                    local_var.turnkey_hash
-                ].model_type = build.ModelType.PYTORCH_COMPILED
+                tracer_args.models_found[local_var.turnkey_hash].model_type = (
+                    build.ModelType.PYTORCH_COMPILED
+                )
 
             # Starting in version 2.2.0, torch dynamo added wrappers to callbacks
             # while tracing frames, which conflicts with TurnkeML's analysis. Here,
             # we supress errors caused by those callback wrappers and only raise an
             # error if the compiled model actually tries to execute within TurnkeyML.
-            td = torch._dynamo # pylint: disable=protected-access
+            td = torch._dynamo  # pylint: disable=protected-access
             td.config.suppress_errors = True
             if hasattr(td.eval_frame, "guarded_backend_cache"):
-                td.eval_frame.guarded_backend_cache.skip_backend_check_for_run_only_mode = True
+                td.eval_frame.guarded_backend_cache.skip_backend_check_for_run_only_mode = (
+                    True
+                )
 
             return
 
@@ -632,14 +639,14 @@ def explore_frame(
             model_info = tracer_args.models_found[model_hash]
 
             if invocation_hash not in model_info.unique_invocations:
-                model_info.unique_invocations[
-                    invocation_hash
-                ] = util.UniqueInvocationInfo(
-                    hash=invocation_hash,
-                    is_target=invocation_hash in tracer_args.targets
-                    or len(tracer_args.targets) == 0,
-                    input_shapes=input_shapes,
-                    parent_hash=parent_invocation_hash,
+                model_info.unique_invocations[invocation_hash] = (
+                    util.UniqueInvocationInfo(
+                        hash=invocation_hash,
+                        is_target=invocation_hash in tracer_args.targets
+                        or len(tracer_args.targets) == 0,
+                        input_shapes=input_shapes,
+                        parent_hash=parent_invocation_hash,
+                    )
                 )
             model_info.last_unique_invocation_executed = invocation_hash
 

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -13,13 +13,19 @@ import turnkeyml.common.filesystem as fs
 
 
 def _spinner(message):
-    parent_process = psutil.Process(pid=os.getppid())
-    while parent_process.status() == psutil.STATUS_RUNNING:
-        for cursor in ["   ", ".  ", ".. ", "..."]:
-            time.sleep(0.5)
-            status = f"      {message}{cursor}\r"
-            sys.stdout.write(status)
-            sys.stdout.flush()
+    try:
+        parent_process = psutil.Process(pid=os.getppid())
+        while parent_process.status() == psutil.STATUS_RUNNING:
+            for cursor in ["   ", ".  ", ".. ", "..."]:
+                time.sleep(0.5)
+                status = f"      {message}{cursor}\r"
+                sys.stdout.write(status)
+                sys.stdout.flush()
+    except psutil.NoSuchProcess:
+        # If the parent process stopped existing, we can
+        # safely assume the spinner no longer needs to spin
+        # NOTE: this only seems to be needed on Windows
+        pass
 
 
 def _name_is_file_safe(name: str):
@@ -310,7 +316,7 @@ class Sequence(Stage):
 
             # Broad exception is desirable as we want to capture
             # all exceptions (including those we can't anticipate)
-            except Exception as e: # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
 
                 # Update Stage Status
                 stats.save_model_eval_stat(

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -13,8 +13,8 @@ import turnkeyml.common.filesystem as fs
 
 
 def _spinner(message):
-    parent_pid = os.getppid()
-    while psutil.pid_exists(parent_pid):
+    parent_process = psutil.Process(pid=os.getppid())
+    while parent_process.status == psutil.STATUS_RUNNING:
         for cursor in ["   ", ".  ", ".. ", "..."]:
             time.sleep(0.5)
             status = f"      {message}{cursor}\r"

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -14,7 +14,7 @@ import turnkeyml.common.filesystem as fs
 
 def _spinner(message):
     parent_process = psutil.Process(pid=os.getppid())
-    while parent_process.status == psutil.STATUS_RUNNING:
+    while parent_process.status() == psutil.STATUS_RUNNING:
         for cursor in ["   ", ".  ", ".. ", "..."]:
             time.sleep(0.5)
             status = f"      {message}{cursor}\r"

--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -68,7 +68,9 @@ def parse_evaluation_id(line: str, current_value: str):
         # This indicates a stats file was created for this evaluation
         # Expected phrase: "Capturing statistics in turnkey_stats.yaml
         #   under evaluation ID: {evaluation_id}"
-        return line.split("ID: ")[1].rstrip()
+        return line.replace(
+            "Capturing statistics in turnkey_stats.yaml under evaluation ID: ", ""
+        ).rstrip()
     else:
         # Don't replace a previously-parsed value with None
         # if we have already found one
@@ -90,7 +92,9 @@ def parse_build_name(line: str, current_value: str):
         # which is why we use this line to find the build directory.
         # Expected phrase:
         #   "Build dir:      {cache_dir}/{build_name}"
-        return os.path.basename(os.path.normpath(line.split(":")[1].rstrip()))
+        return os.path.basename(
+            os.path.normpath(line.replace("Build dir:", "").rstrip())
+        )
     else:
         # Don't replace a previously-parsed value with None
         # if we have already found one

--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -58,7 +58,7 @@ class WatchdogTimer(Thread):
         self.cancelled.set()
 
 
-def parse_evaluation_id(line: str, current_value: str):
+def parse_evaluation_id(line: str, current_value: str)  -> Optional[str]:
     """
     Parse the evaluation ID from a line of turnkey process output.
     Used to clean up after a turnkey subprocess is killed.
@@ -79,7 +79,7 @@ def parse_evaluation_id(line: str, current_value: str):
         return None
 
 
-def parse_build_name(line: str, current_value: str):
+def parse_build_name(line: str, current_value: str) -> Optional[str]:
     """
     Parse the build directory from a line of turnkey process output.
     Used to clean up after a turnkey subprocess is killed.

--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -31,6 +31,7 @@ class WatchdogTimer(Thread):
         self.cancelled = Event()
         self.blocked = Lock()
         self.timeout_reached = False
+        self.deadline = None
 
     def run(self):
         self.restart()  # don't start timer until `.start()` is called
@@ -305,7 +306,8 @@ def run_turnkey(
 
             if build_name:
                 printing.log_info(
-                    f"Detected failed build {build_name}. The parent process will attempt to clean up."
+                    f"Detected failed build {build_name}. "
+                    "The parent process will attempt to clean up."
                 )
                 if "--lean-cache" in command:
                     printing.log_info("Removing build artifacts...")

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -153,8 +153,12 @@ class FunctionStatus(enum.Enum):
 
     ERROR = "error"
 
+    # TIMEOUT means the stage/build/benchmark failed because it exceeded the timeout
+    # set for the turnkey command.
+    TIMEOUT = "timeout"
+
     # KILLED means the build/benchmark failed because the system killed it. This can
-    # happen because of an out-of-memory (OOM), timeout, system shutdown, etc.
+    # happen because of an out-of-memory (OOM), system shutdown, etc.
     # You should proceed by re-running the build and keeping an eye on it to observe
     # why it is being killed (e.g., watch the RAM utilization to diagnose an OOM).
     KILLED = "killed"

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -367,14 +367,20 @@ class Keys:
     STAGE_STATUS = "stage_status"
 
 
+def stats_file(cache_dir: str, build_name: str):
+    """
+    Returns the expected location of the turnkey stats file
+    """
+    dir = build.output_dir(cache_dir, build_name)
+    return os.path.join(dir, "turnkey_stats.yaml")
+
+
 class Stats:
     def __init__(self, cache_dir: str, build_name: str, evaluation_id: str = None):
-        output_dir = build.output_dir(cache_dir, build_name)
-
-        self.file = os.path.join(output_dir, "turnkey_stats.yaml")
+        self.file = stats_file(cache_dir, build_name)
         self.evaluation_id = evaluation_id
 
-        os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(os.path.dirname(self.file), exist_ok=True)
         if not os.path.exists(self.file):
             initial = {Keys.EVALUATIONS: {}}
             _save_yaml(initial, self.file)

--- a/test/cli.py
+++ b/test/cli.py
@@ -885,8 +885,6 @@ class Testing(unittest.TestCase):
          - the timeout kills the process before it has a chance to create a stats.yaml file
         """
 
-        print(cache_dir)
-
         testargs = [
             "turnkey",
             "benchmark",


### PR DESCRIPTION
Closes #33 

# Before

The turnkey job would fail and turnkey would just move on to the next input without cleaning up.

Stats file result:

```
evaluations:
  x86_ort:
    benchmark_status: not_started
    build_status: incomplete
    device_type: x86
    iterations: 100
    onnx_file: /home/jfowers/.cache/turnkey/linear_selftest_76af2f62/onnx/linear_selftest_76af2f62-op14-base.onnx
    runtime: ort
    selected_sequence_of_stages:
    - export_pytorch
    - optimize_onnx
    stage_duration:export_pytorch: '-'
    stage_duration:optimize_onnx: '-'
    stage_status:export_pytorch: successful
    stage_status:optimize_onnx: incomplete
    torch_export_validity: valid
```

Command line result:

```
(tklocal) (base) jfowers@LAPTOP-5VK03G46:~/turnkeyml/models/selftest$ turnkey linear.py --process-isolation --rebuild always

Info: Running turnkey on linear.py

Info: Starting process with command: turnkey benchmark ~/turnkeyml/models/selftest/linear.py  --rebuild="always" --device="x86" --runtime="ort" --iterations="100"   --max-depth="0" 

Info: Running turnkey on ~/turnkeyml/models/selftest/linear.py

Models discovered during profiling:

linear.py:
        model (executed 1x)
                Model Type:     Pytorch (torch.nn.Module)
                Class:          LinearTestModel (<class '__main__.LinearTestModel'>)
                Location:       /home/jfowers/turnkeyml/models/selftest/linear.py, line 21
                Parameters:     110 (440.0 B)
                Input Shape:    'x': (10,)
                Hash:           76af2f62
                Build dir:      /home/jfowers/.cache/turnkey/linear_selftest_76af2f62
                Status:         Computing...





Building "linear_selftest_76af2f62"
    ✓ Exporting PyTorch to ONNX   
      Optimizing ONNX file   
Error: Process was terminated with the error shown below. turnkey will move on to the next input.
       Command '['turnkey', 'benchmark', '~/turnkeyml/models/selftest/linear.py', '--rebuild=always', '--device=x86', '--runtime=ort', '--iterations=100', '--max-depth=0']' returned non-zero exit status 1.

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████


Woohoo! The 'benchmark' command is complete.
```

# Stats file cleanup

## Timed out build

Note how `build_status` and `stage_status:export_pytorch` both show `timeout` instead of `incomplete` now.

```
evaluations:
  x86_ort:
    benchmark_status: not_started
    build_status: timeout
    device_type: x86
    iterations: 100
    runtime: ort
    selected_sequence_of_stages:
    - export_pytorch
    - optimize_onnx
    stage_duration:export_pytorch: '-'
    stage_duration:optimize_onnx: '-'
    stage_status:export_pytorch: timeout
    stage_status:optimize_onnx: not_started
```

Timeout handling also works for no-build evaluations such as with torch-compiled:

```
evaluations:
  x86_torch-compiled:
    benchmark_status: timeout
    build_status: not_started
    device_type: x86
    iterations: 100
    runtime: torch-compiled
```

## Killed build

Note how the `build_status` and `stage_status:optimize_onnx` are both `killed` instead of `incomplete` now on a killed build.

```
evaluations:
  x86_ort:
    benchmark_status: not_started
    build_status: killed
    device_type: x86
    iterations: 100
    onnx_file: /home/jfowers/.cache/turnkey/linear_selftest_76af2f62/onnx/linear_selftest_76af2f62-op14-base.onnx
    runtime: ort
    selected_sequence_of_stages:
    - export_pytorch
    - optimize_onnx
    stage_duration:export_pytorch: '-'
    stage_duration:optimize_onnx: '-'
    stage_status:export_pytorch: successful
    stage_status:optimize_onnx: killed
    torch_export_validity: valid
```

# Lean Cache Fix

If the `--lean-cache` flag is set, turnkey will clean the build directory of the failed job before moving on.

```
(tklocal) (base) jfowers@LAPTOP-5VK03G46:~/turnkeyml/models/selftest$ turnkey linear.py --process-isolation --rebuild always --lean-cache
 
Info: Running turnkey on linear.py

Info: Starting process with command: turnkey benchmark ~/turnkeyml/models/selftest/linear.py --lean-cache --rebuild="always" --device="x86" --runtime="ort" --iterations="100"   --max-depth="0" 

Info: Running turnkey on ~/turnkeyml/models/selftest/linear.py

Models discovered during profiling:

linear.py:
        model (executed 1x)
                Model Type:     Pytorch (torch.nn.Module)
                Class:          LinearTestModel (<class '__main__.LinearTestModel'>)
                Location:       /home/jfowers/turnkeyml/models/selftest/linear.py, line 21
                Parameters:     110 (440.0 B)
                Input Shape:    'x': (10,)
                Hash:           76af2f62
                Build dir:      /home/jfowers/.cache/turnkey/linear_selftest_76af2f62
                Status:         Computing...





Building "linear_selftest_76af2f62"
    ✓ Exporting PyTorch to ONNX   
      Optimizing ONNX file   
Error: Process was terminated with the error shown below. turnkey will move on to the next input.
       Command '['turnkey', 'benchmark', '~/turnkeyml/models/selftest/linear.py', '--lean-cache', '--rebuild=always', '--device=x86', '--runtime=ort', '--iterations=100', '--max-depth=0']' returned non-zero exit status 1.

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████


Detected failed build: linear_selftest_76af2f62

Info: Removing build artifacts...

Woohoo! The 'benchmark' command is complete.
```

# Fix / Regression

Previously, in process isolation mode the build monitor would display the "spinner" aka `...` as it ran. However, if the turnkey process was killed, sometimes the spinner subprocess would keep running, which would make the terminal unusable. The unusability problem has been fixed.

However, there is also a regression. In process isolation mode, the "spinner" prints on a new line every time and looks like this:

```
Building "bert_transformers_bf722986"
      Exporting PyTorch to ONNX   
      Exporting PyTorch to ONNX.  
      Exporting PyTorch to ONNX.. 
      Exporting PyTorch to ONNX...
      Exporting PyTorch to ONNX   
      Exporting PyTorch to ONNX.  
      Exporting PyTorch to ONNX.. 
      Exporting PyTorch to ONNX...
      Exporting PyTorch to ONNX   
    ✓ Exporting PyTorch to ONNX   




Error: Process was terminated with the error shown below. turnkey will move on to the next input.
       
       Command '['turnkey', 'benchmark', '~/turnkeyml/models/transformers/bert.py', '--rebuild=if_needed', '--device=x86', '--runtime=ort', '--iterations=100', '--max-depth=0']' returned non-zero exit status 1.

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████



Info: Detected failed build bert_transformers_bf722986. The parent process will attempt to clean up.

Woohoo! The 'benchmark' command is complete.
```
