### PR TITLE
Correctly assess exceptions for no-build runtimes

### DIFF
--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -84,10 +84,13 @@ def _store_traceback(invocation_info: util.UniqueInvocationInfo):
     invocation_info.status_message = " ".join(invocation_info.status_message.split())
 
 
-def set_status_on_exception(build_state: build.State, stats: fs.Stats):
+def set_status_on_exception(
+    build_required: bool, build_state: build.State, stats: fs.Stats
+):
     # We get `state` when the build tool succeeds, so we can use that to identify
     # whether the exception was thrown during build or benchmark
-    if not build_state:
+    # We also take into account whether a build was requested
+    if build_required and not build_state:
         stats.save_model_eval_stat(
             fs.Keys.BUILD_STATUS, build.FunctionStatus.ERROR.value
         )
@@ -257,13 +260,26 @@ def explore_invocation(
 
         return
 
-    # Initialize build and benchmark status to "not started"
-    stats.save_model_eval_stat(
-        fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_STARTED.value
-    )
-    stats.save_model_eval_stat(
-        fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED.value
-    )
+    # Initialize build and benchmark status to "not started" or
+    # "not applicable" depending on whether that action is part of the
+    # evaluation
+    if runtime_info["build_required"]:
+        stats.save_model_eval_stat(
+            fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_STARTED.value
+        )
+    else:
+        stats.save_model_eval_stat(
+            fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_APPLICABLE.value
+        )
+
+    if Action.BENCHMARK in tracer_args.actions:
+        stats.save_model_eval_stat(
+            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED.value
+        )
+    else:
+        stats.save_model_eval_stat(
+            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_APPLICABLE.value
+        )
 
     build_state = None
     perf = None
@@ -350,7 +366,7 @@ def explore_invocation(
         invocation_info.status_message = f"Build Error: {e}"
         invocation_info.status_message_color = printing.Colors.WARNING
 
-        set_status_on_exception(build_state, stats)
+        set_status_on_exception(runtime_info["build_required"], build_state, stats)
 
         _store_traceback(invocation_info)
 
@@ -370,7 +386,7 @@ def explore_invocation(
         # illegal. In that case we want to halt execution so that users can
         # fix their arguments.
 
-        set_status_on_exception(build_state, stats)
+        set_status_on_exception(runtime_info["build_required"], build_state, stats)
 
         raise e
 
@@ -378,7 +394,7 @@ def explore_invocation(
         invocation_info.status_message = f"Error: {e}."
         invocation_info.status_message_color = printing.Colors.WARNING
 
-        set_status_on_exception(build_state, stats)
+        set_status_on_exception(runtime_info["build_required"], build_state, stats)
 
         _store_traceback(invocation_info)
 
@@ -388,7 +404,7 @@ def explore_invocation(
         invocation_info.status_message = f"Unknown turnkey error: {e}"
         invocation_info.status_message_color = printing.Colors.WARNING
 
-        set_status_on_exception(build_state, stats)
+        set_status_on_exception(runtime_info["build_required"], build_state, stats)
 
         _store_traceback(invocation_info)
 

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -260,25 +260,16 @@ def explore_invocation(
 
         return
 
-    # Initialize build and benchmark status to "not started" or
-    # "not applicable" depending on whether that action is part of the
-    # evaluation
+    # Initialize build and benchmark status to "not started" if
+    # that action is part of the evaluation
     if runtime_info["build_required"]:
         stats.save_model_eval_stat(
             fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_STARTED.value
-        )
-    else:
-        stats.save_model_eval_stat(
-            fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_APPLICABLE.value
         )
 
     if Action.BENCHMARK in tracer_args.actions:
         stats.save_model_eval_stat(
             fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED.value
-        )
-    else:
-        stats.save_model_eval_stat(
-            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_APPLICABLE.value
         )
 
     build_state = None

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -144,6 +144,9 @@ class FunctionStatus(enum.Enum):
     successfully or not.
     """
 
+    # NOT_APPLICABLE means the stage/build/benchmark was not requested.
+    NOT_APPLICABLE = "not_applicable"
+
     # SUCCESSFUL means the stage/build/benchmark completed successfully.
     SUCCESSFUL = "successful"
 

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -144,9 +144,6 @@ class FunctionStatus(enum.Enum):
     successfully or not.
     """
 
-    # NOT_APPLICABLE means the stage/build/benchmark was not requested.
-    NOT_APPLICABLE = "not_applicable"
-
     # SUCCESSFUL means the stage/build/benchmark completed successfully.
     SUCCESSFUL = "successful"
 

--- a/src/turnkeyml/run/torchrt/runtime.py
+++ b/src/turnkeyml/run/torchrt/runtime.py
@@ -68,6 +68,8 @@ class TorchRT(BaseRT):
             self.model = torch.compile(self.model)
 
     def benchmark(self) -> MeasuredPerformance:
+        # FIXME DONT COMMIT
+        raise Exception
         per_iteration_latency = [0] * self.iterations
         for idx in range(self.iterations):
             start_time = time.perf_counter()

--- a/src/turnkeyml/run/torchrt/runtime.py
+++ b/src/turnkeyml/run/torchrt/runtime.py
@@ -68,8 +68,6 @@ class TorchRT(BaseRT):
             self.model = torch.compile(self.model)
 
     def benchmark(self) -> MeasuredPerformance:
-        # FIXME DONT COMMIT
-        raise Exception
         per_iteration_latency = [0] * self.iterations
         for idx in range(self.iterations):
             start_time = time.perf_counter()

--- a/src/turnkeyml/run/torchrt/runtime.py
+++ b/src/turnkeyml/run/torchrt/runtime.py
@@ -58,7 +58,7 @@ class TorchRT(BaseRT):
             # First ensure we have the required version of Pytorch
             clean_torch_version = self.runtime_version.split("+")[0]
             if version.parse(clean_torch_version) < version.parse("2.0.0"):
-                exp.BenchmarkException(
+                raise exp.BenchmarkException(
                     (
                         f"{self.runtime} can only be used with Pytorch 2.0.0 or above. "
                         f"However, version {self.runtime_version} was found."


### PR DESCRIPTION
Closes #83 by:
- Passing `build_required` into the assessment logic. There can't be a build error if there is no build!
- Added a new FunctionStatus member: `not_applicable`. This is assigned when the evaluation doesn't request a particular function. For example, if `build_required=False` then `build_status=not_applicable`