### PR TITLE
Use the real checkpoint for GPT-J so that it will be 6B params

### DIFF
--- a/models/log.yml
+++ b/models/log.yml
@@ -11,5 +11,6 @@ models_renamed:
     - funnelbase : funnel_small_base
     - luke : mluke_base
     - pegasus : pegasus_x_large
+    - gptj : gptj_tiny
 models_deleted:
     - None

--- a/models/transformers/gptj_tiny.py
+++ b/models/transformers/gptj_tiny.py
@@ -12,9 +12,9 @@ pretrained, batch_size, max_seq_length = parse(
 
 # Model and input configurations
 if pretrained:
-    model = GPTJModel.from_pretrained("EleutherAI/gpt-j-6B")
+    model = GPTJModel.from_pretrained("hf-internal-testing/tiny-random-gptj")
 else:
-    config = AutoConfig.from_pretrained("EleutherAI/gpt-j-6B")
+    config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gptj")
     model = GPTJModel(config)
 
 # Make sure the user's sequence length fits within the model's maximum


### PR DESCRIPTION
Closes #107 by using the real checkpoint for GPT-J and uses the prior tiny checkpoint in a new script called gptj_tiny.py