### PR TITLE
Enable large models FLOPs 

### DIFF
--- a/src/turnkeyml/analyze/util.py
+++ b/src/turnkeyml/analyze/util.py
@@ -127,9 +127,13 @@ def get_onnx_total_flops(onnx_model) -> Union[int, None]:
     from multiply-accumulates (MACs) where FLOPs == 2 * MACs.
     """
     try:
-        model = onnx.shape_inference.infer_shapes(
-            onnx.load(onnx_model), strict_mode=True, data_prop=True
+        onnx.shape_inference.infer_shapes_path(
+            model_path=onnx_model,
+            output_path=onnx_model,
+            strict_mode=True,
+            data_prop=True,
         )
+        model = onnx.load(onnx_model)
     except Exception as e:  # pylint: disable=broad-except
         printing.log_warning(f"Failed to get ONNX FLOPs from {onnx_model}: {str(e)}")
         return None

--- a/src/turnkeyml/analyze/util.py
+++ b/src/turnkeyml/analyze/util.py
@@ -133,7 +133,7 @@ def get_onnx_total_flops(onnx_model) -> Union[int, None]:
             strict_mode=True,
             data_prop=True,
         )
-        model = onnx.load(onnx_model)
+        model = onnx.load(onnx_model, load_external_data=False)
     except Exception as e:  # pylint: disable=broad-except
         printing.log_warning(f"Failed to get ONNX FLOPs from {onnx_model}: {str(e)}")
         return None


### PR DESCRIPTION
I ran all the same tests from the original PR locally plus verified we are getting FLOPs for the following larger models:

beit_large_patch16_512, bloom, deberta_xlarge, mt5_large, pegasus_x_large, and xlm.
 