### PR TITLE
Record error log content into stats.yaml

### DIFF
--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -323,6 +323,9 @@ class Sequence(Stage):
                     stage.status_key, build.FunctionStatus.ERROR.value
                 )
 
+                # Save the log file for the failed stage to stats for easy reference
+                stats.save_eval_error_log(stage.logfile_path)
+
                 # Advance the cursor below the monitor so
                 # we can print an error message
                 stage_depth_in_sequence = self.get_depth() - self.get_names().index(

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -379,7 +379,7 @@ def _clean_logfile(logfile_lines: List[str]) -> List[str]:
     """
     Remove the whitespace and empty lines from an array of logfile lines
     """
-    return [line.rstrip() for line in logfile_lines if line.rstrip()]
+    return "\n".join([line.rstrip() for line in logfile_lines if line.rstrip()])
 
 
 def stats_file(cache_dir: str, build_name: str):
@@ -471,10 +471,10 @@ class Stats:
                         "NOTICE: This copy of the log has been truncated to the first "
                         f"{start_cutoff} and last {abs(end_cutoff)} lines "
                         f"to save space. Please see {logfile_path} "
-                        "to see the full log."
+                        "to see the full log.\n"
                     )
 
-                    stats_log = log_start + [truncation_notice] + log_end
+                    stats_log = log_start + truncation_notice + log_end
                 else:
                     stats_log = _clean_logfile(full_log)
 

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -457,8 +457,8 @@ class Stats:
             with open(logfile_path, "r", encoding="utf-8") as f:
                 full_log = f.readlines()
 
-                # Log files can be quite large, so we will just record the first
-                # 5 and last 25 lines. Users can always open the log file if they
+                # Log files can be quite large, so we will just record the beginning
+                # and ending lines. Users can always open the log file if they
                 # want to see the full log.
                 start_cutoff = 5
                 end_cutoff = -30

--- a/src/turnkeyml/run/basert.py
+++ b/src/turnkeyml/run/basert.py
@@ -76,6 +76,9 @@ class BaseRT(ABC):
         self.outputs_filename = "outputs.json"
         self.runtimes_supported = runtimes_supported
         self.execute_function = execute_function
+        self.logfile_path = os.path.join(
+            self.local_output_dir, f"{runtime}_benchmark_log.txt"
+        )
 
         # Validate runtime is supported
         if runtime not in runtimes_supported:

--- a/src/turnkeyml/run/onnxrt/execute.py
+++ b/src/turnkeyml/run/onnxrt/execute.py
@@ -1,6 +1,7 @@
 """
 The following script is used to get the latency and outputs of a given run on the x86 CPUs.
 """
+
 # pylint: disable = no-name-in-module
 # pylint: disable = import-error
 import os
@@ -64,12 +65,12 @@ def execute_benchmark(
     output_dir: str,
     conda_env_name: str,
     iterations: int,
+    benchmarking_log_file: str,
 ):
     """Execute the benchmark script and retrieve the output."""
 
     python_in_env = plugin_helpers.get_python_path(conda_env_name)
     iterations_file = os.path.join(output_dir, "per_iteration_latency.json")
-    benchmarking_log_file = os.path.join(output_dir, "ort_benchmarking_log.txt")
 
     cmd = [
         python_in_env,

--- a/src/turnkeyml/run/onnxrt/runtime.py
+++ b/src/turnkeyml/run/onnxrt/runtime.py
@@ -84,6 +84,7 @@ class OnnxRT(BaseRT):
             output_dir=output_dir,
             conda_env_name=conda_env_name,
             iterations=self.iterations,
+            benchmarking_log_file=self.logfile_path,
         )
 
     @property

--- a/src/turnkeyml/run/tensorrt/runtime.py
+++ b/src/turnkeyml/run/tensorrt/runtime.py
@@ -98,7 +98,7 @@ class TensorRT(BaseRT):
             output_dir=output_dir,
             onnx_file=onnx_file,
             outputs_file=outputs_file,
-            errors_file=os.path.join(output_dir, "nvidia_error_log.txt"),
+            errors_file=self.logfile_path,
             iterations=self.iterations,
             start_event=start_event,
             stop_event=stop_event,


### PR DESCRIPTION
Closes #103 by including stage and benchmark error log content into stats.yaml

New features:
- `Stats` class has a generic method for saving truncated logfile content to the stats file
- `BaseRT` now has a standardized way to name/access logfiles - all plugins should adopt this

# Demos

## Benchmarking failure

```
evaluations:
  dfac8db5:
    benchmark_status: error
    build_status: successful
    device_type: x86
    error_log:
    - 'Traceback (most recent call last):'
    - '  File "C:\Users\jefowers/.cache/turnkey\resnet18_timm_465f6391\x86_benchmark\within_conda.py",
      line 100, in <module>'
    - '    run_ort_profile('
    - '  File "C:\Users\jefowers/.cache/turnkey\resnet18_timm_465f6391\x86_benchmark\within_conda.py",
      line 18, in run_ort_profile'
    - '    raise Exception("Hey look, an exception!")'
    - 'Exception: Hey look, an exception!'
```


## Opset 18 export failure

Note the truncation notice.

```
evaluations:
  7c5058e9:
    build_status: error
    device_type: x86
    error_log:
    - Exporting PyTorch to ONNX
    - 'C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\__init__.py:1493:
      TracerWarning: Converting a tensor to a Python boolean might cause the trace
      to be incorrect. We can''t record the data flow of Python values, so this value
      will be treated as a constant in the future. This means that the trace might
      not generalize to other inputs!'
    - '  assert condition, message'
    - Unexpected error during verification.
    - 'jit graph:  graph(%input.1 : Float(1, 3, 224, 224, strides=[150528, 50176,
      224, 1], requires_grad=0, device=cpu),'
    - 'NOTICE: This copy of the log has been truncated to the first 5 and last 30
      lines to save space. Please see C:\Users\jefowers/.cache/turnkey\beit_large_patch16_224_timm_8078d3d1\log_export_pytorch.txt
      to see the full log.'
    - '  %2991 : Long(1, strides=[1], requires_grad=0, device=cpu) = onnx::Constant[value={1}]()
      # C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\timm\models\beit.py:421:0'
    - '  %aten::mean_2743 : Float(1, 196, 1024, strides=[201728, 1024, 1], requires_grad=0,
      device=cpu) = onnx::Slice(%x.187, %2989, %2990, %2988, %2991) # C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\timm\models\beit.py:421:0'
    - '  %x.191 : Float(1, 1024, strides=[1024, 1], requires_grad=0, device=cpu) =
      onnx::ReduceMean[axes=[1], keepdims=0](%aten::mean_2743) # C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\timm\models\beit.py:421:0'
    - '  %input.292 : Float(1, 1024, strides=[1024, 1], requires_grad=0, device=cpu)
      = onnx::LayerNormalization[axis=-1, epsilon=9.9999999999999995e-07](%x.191,
      %fc_norm.weight, %fc_norm.bias) # C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\nn\functional.py:2546:0'
    - '  %2525 : Float(1, 1000, strides=[1000, 1], requires_grad=0, device=cpu) =
      onnx::Gemm[alpha=1., beta=1., transB=1](%input.292, %head.weight, %head.bias)
      # C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\nn\modules\linear.py:116:0'
    - '  return (%2525)'
    - 'C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\onnx\utils.py:1548:
      OnnxExporterWarning: Exporting to ONNX opset version 18 is not supported. by
      ''torch.onnx.export()''. The highest opset version supported is 17. To use a
      newer opset version, consider ''torch.onnx.dynamo_export()''. Note that dynamo_export()
      is in preview. Please report errors with dynamo_export() as Github issues to
      https://github.com/pytorch/pytorch/issues.'
    - '  warnings.warn('
    - 'Traceback (most recent call last):'
    - '  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\onnx\utils.py",
      line 1703, in _export'
    - '    _C._check_onnx_proto(proto)'
    - 'RuntimeError: Unrecognized attribute: axes for operator ReduceMean'
    - '==> Context: Bad node spec for node. Name: /ReduceMean OpType: ReduceMean'
    - 'The above exception was the direct cause of the following exception:'
    - 'Traceback (most recent call last):'
    - '  File "C:\work\turnkeyml\src\turnkeyml\build\stage.py", line 135, in fire_helper'
    - '    state = self.fire(state)'
    - '  File "C:\work\turnkeyml\src\turnkeyml\build\export.py", line 328, in fire'
    - '    torch.onnx.export('
    - '  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\onnx\utils.py",
      line 516, in export'
    - '    _export('
    - '  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tklocal\lib\site-packages\torch\onnx\utils.py",
      line 1705, in _export'
    - '    raise errors.CheckerError(e) from e'
    - 'torch.onnx.errors.CheckerError: Unrecognized attribute: axes for operator ReduceMean'
    - '==> Context: Bad node spec for node. Name: /ReduceMean OpType: ReduceMean'
  ```