### PR TITLE
Directly benchmark build directories

### DIFF
--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -365,7 +365,7 @@ def explore_invocation(
 
     build_state = None
     perf = None
-    benchmark_logfile_path = None
+    benchmark_logfile_path = ""
     try:
         # Run the build tool (if needed by the runtime)
         if runtime_info["build_required"]:

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -429,9 +429,9 @@ def main():
     clean_group = clean_parser.add_mutually_exclusive_group(required=True)
 
     clean_group.add_argument(
-        "build_names",
+        "build_name",
         nargs="?",
-        help="Name of the specific build(s) to be cleaned, within the cache directory",
+        help="Name of the specific build to be cleaned, within the cache directory",
     )
 
     clean_group.add_argument(

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -487,6 +487,20 @@ def main():
         action="store_true",
     )
 
+    skip_policy_default = "attempted"
+    cache_benchmark_parser.add_argument(
+        "--skip",
+        choices=[skip_policy_default, "failed", "successful", "none"],
+        dest="skip_policy",
+        help=f"Sets the policy for skipping benchmark attempts (defaults to {skip_policy_default})."
+        "`attempted` means to skip any previously-attempted benchmark, whether it succeeded or failed."
+        "`failed` skips benchmarks that have already failed once."
+        "`successful` skips benchmarks that have already succeeded."
+        "`none` will attempt all benchmarks, regardless of whether they were previously attempted.",
+        required=False,
+        default=skip_policy_default,
+    )
+
     cache_benchmark_parser.add_argument(
         "--timeout",
         type=int,
@@ -506,7 +520,7 @@ def main():
         default=None,
     )
 
-    cache_benchmark_group.add_argument(
+    cache_benchmark_parser.add_argument(
         "--iterations",
         dest="iterations",
         type=int,
@@ -515,7 +529,7 @@ def main():
               the benchmarking performance (e.g., mean latency)",
     )
 
-    cache_benchmark_group.add_argument(
+    cache_benchmark_parser.add_argument(
         "--rt-args",
         dest="rt_args",
         type=str,

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -493,7 +493,8 @@ def main():
         choices=[skip_policy_default, "failed", "successful", "none"],
         dest="skip_policy",
         help=f"Sets the policy for skipping benchmark attempts (defaults to {skip_policy_default})."
-        "`attempted` means to skip any previously-attempted benchmark, whether it succeeded or failed."
+        "`attempted` means to skip any previously-attempted benchmark, "
+        "whether it succeeded or failed."
         "`failed` skips benchmarks that have already failed once."
         "`successful` skips benchmarks that have already succeeded."
         "`none` will attempt all benchmarks, regardless of whether they were previously attempted.",
@@ -506,7 +507,7 @@ def main():
         type=int,
         default=None,
         help="Benchmark timeout, in seconds, after which each benchmark will be canceled "
-        f"(default={DEFAULT_TIMEOUT_SECONDS}).",
+        "(default: no timeout).",
     )
 
     cache_benchmark_parser.add_argument(

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -258,7 +258,7 @@ def clean_builds(args):
     if args.clean_all:
         builds = get_available_builds(args.cache_dir)
     else:
-        builds = [args.build_name]
+        builds = args.build_names
 
     for build in builds:
         if is_build_dir(args.cache_dir, build):

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -258,7 +258,7 @@ def clean_builds(args):
     if args.clean_all:
         builds = get_available_builds(args.cache_dir)
     else:
-        builds = args.build_names
+        builds = [args.build_name]
 
     for build in builds:
         if is_build_dir(args.cache_dir, build):

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -1,0 +1,166 @@
+from typing import List, Dict, Optional
+from multiprocessing import Process, ProcessError, TimeoutError
+import turnkeyml.common.build as build
+import turnkeyml.common.exceptions as exp
+import turnkeyml.common.filesystem as fs
+import turnkeyml.common.printing as printing
+from turnkeyml.analyze.script import set_status_on_exception
+from turnkeyml.run.devices import SUPPORTED_RUNTIMES, apply_default_runtime
+
+
+def benchmark_build(
+    cache_dir: str,
+    build_name: str,
+    runtime: str,
+    iterations: int,
+    rt_args: Optional[Dict] = None,
+):
+    """
+    Benchmark the build artifact from a successful turnkey build.
+
+    For example, `turnkey linear.py --build-only` would produce a build whose
+    resulting artifact is an optimized ONNX file. This function would benchmark
+    that optimized ONNX file.
+
+    How it works:
+        1. Attempt to load build state from the cache_dir/build_name specified
+        2. Pass the build state directly into an instance of BaseRT and
+            run the benchmark method
+        3. Save stats to the same evaluation entry from the original build
+    """
+
+    build_path = build.output_dir(cache_dir, build_name)
+
+    state = build.load_state(cache_dir, build_name)
+
+    if state.build_status != build.FunctionStatus.SUCCESSFUL:
+        raise exp.BenchmarkException(
+            "Only successful builds can be benchmarked with this "
+            f"function, however selected build at {build_path} "
+            f"has state: {state.build_status}"
+        )
+
+    selected_runtime = apply_default_runtime(state.config.device, runtime)
+
+    if rt_args is None:
+        rt_args_to_use = {}
+    else:
+        rt_args_to_use = rt_args
+
+    try:
+        runtime_info = SUPPORTED_RUNTIMES[selected_runtime]
+    except KeyError:
+        # User should never get this far without hitting an actionable error message,
+        # but let's raise an exception just in case.
+        raise exp.BenchmarkException(
+            f"Selected runtime is not supported: {selected_runtime}"
+        )
+
+    # Load the stats file using the same evaluation ID used in the original build.
+    # This allows us to augment those stats with more data instead of starting a new
+    # evaluation entry.
+    stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
+
+    stats.save_model_eval_stat(
+        fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.INCOMPLETE.value
+    )
+
+    benchmark_logfile_path = ""
+    try:
+        # Instantiate BaseRT for the selected runtime
+        runtime_handle = runtime_info["RuntimeClass"](
+            cache_dir=cache_dir,
+            build_name=build_name,
+            stats=stats,
+            iterations=iterations,
+            model=state.results[0],
+            # The `inputs` argument to BaseRT is only meant for
+            # benchmarking runtimes that have to keep their inputs
+            # in memory (e.g., `torch-eager`). We provide None here
+            # because this function only works with runtimes that
+            # keep their model and inputs on disk.
+            inputs=None,
+            device_type=state.config.device,
+            runtime=selected_runtime,
+            **rt_args_to_use,
+        )
+        benchmark_logfile_path = runtime_handle.logfile_path
+        perf = runtime_handle.benchmark()
+
+        for key, value in vars(perf).items():
+            stats.save_model_eval_stat(
+                key=key,
+                value=value,
+            )
+
+        stats.save_model_eval_stat(
+            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL.value
+        )
+    except Exception as e:
+        set_status_on_exception(
+            runtime_info["build_required"], state, stats, benchmark_logfile_path
+        )
+
+        raise e
+
+
+def benchmark_cache_cli(args):
+    """
+    Wrapper function for benchmark_cache() that passes in the CLI arguments
+    """
+
+    benchmark_cache(
+        cache_dir=args.cache_dir,
+        build_names=args.build_names,
+        benchmark_all=args.benchmark_all,
+        runtime=args.runtime,
+        iterations=args.iterations,
+        timeout=args.timeout,
+        rt_args=args.rt_args,
+    )
+
+
+def benchmark_cache(
+    cache_dir: str,
+    build_names: List[str],
+    benchmark_all: bool,
+    runtime: str,
+    iterations: int = 100,
+    timeout: Optional[int] = None,
+    rt_args: Optional[Dict] = None,
+):
+    """
+    Benchmark one or more builds in a cache using the benchmark_build()
+    function.
+
+    These benchmarks always run in process isolation mode because the purpose
+    of this function is to quickly iterate over many builds.
+    """
+
+    if benchmark_all:
+        builds = fs.get_available_builds(cache_dir)
+    else:
+        builds = build_names
+
+    for build_name in builds:
+        printing.log_info(f"Attempting to benchmark: {build_name}")
+
+        p = Process(
+            target=benchmark_build,
+            args=[cache_dir, build_name, runtime, iterations, rt_args],
+        )
+        p.start()
+
+        try:
+            p.join(timeout=timeout)
+        except TimeoutError as e:
+            # Set the timeout stat
+            state = build.load_state(cache_dir, build_name)
+            stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
+            stats.save_model_eval_stat(
+                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.TIMEOUT.value
+            )
+
+            print(e)
+
+        printing.log_success(f"Done benchmarking: {build_name}")

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -1,11 +1,12 @@
 from typing import List, Dict, Optional
-from multiprocessing import Process, ProcessError, TimeoutError
+from multiprocessing import Process, TimeoutError
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
 import turnkeyml.common.filesystem as fs
 import turnkeyml.common.printing as printing
 from turnkeyml.analyze.script import set_status_on_exception
 from turnkeyml.run.devices import SUPPORTED_RUNTIMES, apply_default_runtime
+import turnkeyml.cli.parser_helpers as parser_helpers
 
 
 def benchmark_build(
@@ -109,6 +110,8 @@ def benchmark_cache_cli(args):
     Wrapper function for benchmark_cache() that passes in the CLI arguments
     """
 
+    rt_args = parser_helpers.decode_args(args.rt_args)
+
     benchmark_cache(
         cache_dir=args.cache_dir,
         build_names=args.build_names,
@@ -117,7 +120,7 @@ def benchmark_cache_cli(args):
         runtime=args.runtime,
         iterations=args.iterations,
         timeout=args.timeout,
-        rt_args=args.rt_args,
+        rt_args=rt_args,
     )
 
 

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -1,8 +1,6 @@
 from typing import List, Dict, Optional
-import concurrent.futures
 import multiprocessing
 import traceback
-import subprocess
 import tqdm
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
@@ -69,14 +67,12 @@ def benchmark_build(
         rt_args: same as turnkey
     """
 
-    build_path = build.output_dir(cache_dir, build_name)
-
     state = build.load_state(cache_dir, build_name)
 
     if state.build_status != build.FunctionStatus.SUCCESSFUL:
         raise exp.BenchmarkException(
             "Only successful builds can be benchmarked with this "
-            f"function, however selected build at {build_path} "
+            f"function, however selected build at {build_name} "
             f"has state: {state.build_status}"
         )
 
@@ -140,6 +136,9 @@ def benchmark_build(
                 value=value,
             )
 
+        # Inform the user of the result
+        perf.print()
+
         stats.save_model_eval_stat(
             fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL.value
         )
@@ -171,7 +170,6 @@ def benchmark_cache_cli(args):
         iterations=args.iterations,
         timeout=args.timeout,
         rt_args=rt_args,
-        # process_isolation=True,
     )
 
 
@@ -184,7 +182,6 @@ def benchmark_cache(
     iterations: int = 100,
     timeout: Optional[int] = None,
     rt_args: Optional[Dict] = None,
-    # process_isolation: bool = False,
 ):
     """
     Benchmark one or more builds in a cache using the benchmark_build()

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -205,7 +205,7 @@ def benchmark_cache(
         "This is an experimental feature. Our plan is to deprecate it "
         "in favor of a new command, `turnkey benchmark cache/*`, ASAP. "
         "Please see https://github.com/onnx/turnkeyml/issues/115 "
-        "for more info."
+        "for more info.\n\n"
     )
 
     if benchmark_all:

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -217,7 +217,7 @@ def benchmark_cache(
     first = True
 
     # Iterate over all of the selected builds and benchmark them
-    for build_name in tqdm.tqdm(builds):
+    for build_name in tqdm(builds):
         if not fs.is_build_dir(cache_dir, build_name):
             raise exp.CacheError(
                 f"No build found with name: {build_name}. "

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -1,7 +1,6 @@
 from typing import List, Dict, Optional
 import multiprocessing
 import traceback
-import tqdm
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
 import turnkeyml.common.filesystem as fs
@@ -9,6 +8,17 @@ import turnkeyml.common.printing as printing
 from turnkeyml.analyze.script import set_status_on_exception
 from turnkeyml.run.devices import SUPPORTED_RUNTIMES, apply_default_runtime
 import turnkeyml.cli.parser_helpers as parser_helpers
+
+# The licensing for tqdm is confusing. Pending a legal scan,
+# the following code provides tqdm to users who have installed
+# it already, while being transparent to users who do not
+# have tqdm installed.
+try:
+    from tqdm import tqdm
+except ImportError:
+
+    def tqdm(iterable, **kwargs):  # pylint: disable=unused-argument
+        return iterable
 
 
 class Process(multiprocessing.Process):
@@ -192,7 +202,7 @@ def benchmark_cache(
     """
 
     printing.log_warning(
-        "This is an experimental feature. Our plan is to deprecate it"
+        "This is an experimental feature. Our plan is to deprecate it "
         "in favor of a new command, `turnkey benchmark cache/*`, ASAP. "
         "Please see https://github.com/onnx/turnkeyml/issues/115 "
         "for more info."

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -191,6 +191,13 @@ def benchmark_cache(
     of this function is to quickly iterate over many builds.
     """
 
+    printing.log_warning(
+        "This is an experimental feature. Our plan is to deprecate it"
+        "in favor of a new command, `turnkey benchmark cache/*`, ASAP. "
+        "Please see https://github.com/onnx/turnkeyml/issues/115 "
+        "for more info."
+    )
+
     if benchmark_all:
         builds = fs.get_available_builds(cache_dir)
     else:
@@ -201,6 +208,12 @@ def benchmark_cache(
 
     # Iterate over all of the selected builds and benchmark them
     for build_name in tqdm.tqdm(builds):
+        if not fs.is_build_dir(cache_dir, build_name):
+            raise exp.CacheError(
+                f"No build found with name: {build_name}. "
+                "Try running `turnkey cache list` to see the builds in your build cache."
+            )
+
         state = build.load_state(cache_dir, build_name)
         stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
 

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -151,7 +151,7 @@ def benchmark_build(
         raise e
 
     # Check whether this benchmark left the device and runtime in a good state
-    if first and "requirement_check" in runtime_info:
+    if "requirement_check" in runtime_info:
         runtime_info["requirement_check"]()
 
 

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -152,7 +152,11 @@ def benchmark_cache(
         stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
 
         eval_stats = stats.evaluation_stats
-        if fs.Keys.BENCHMARK_STATUS in eval_stats:
+        if (
+            fs.Keys.BENCHMARK_STATUS in eval_stats
+            and eval_stats[fs.Keys.BENCHMARK_STATUS]
+            != build.FunctionStatus.NOT_STARTED.value
+        ):
             if skip_policy == "attempted":
                 printing.log_warning(
                     f"Skipping because it was previously attempted: {build_name}"

--- a/test/analysis.py
+++ b/test/analysis.py
@@ -31,128 +31,6 @@ except ImportError as e:
     )
 
 
-# We generate a corpus on to the filesystem during the test
-# to get around how weird bake tests are when it comes to
-# filesystem access
-
-test_scripts_dot_py = {
-    "linear_pytorch.py": """# labels: test_group::selftest license::mit framework::pytorch tags::selftest,small
-import torch
-import argparse
-
-torch.manual_seed(0)
-
-# Receive command line arg
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "-m",
-    "--my-arg",
-)
-args = parser.parse_args()
-print(f"Received arg {args.my_arg}")
-
-class LinearTestModel(torch.nn.Module):
-    def __init__(self, input_features, output_features):
-        super(LinearTestModel, self).__init__()
-        self.fc = torch.nn.Linear(input_features, output_features)
-
-    def forward(self, x):
-        output = self.fc(x)
-        return output
-
-input_features = 10
-output_features = 10
-
-# Model and input configurations
-model = LinearTestModel(input_features, output_features)
-unexecuted_model = LinearTestModel(input_features+1, output_features)
-inputs = {"x": torch.rand(input_features)}
-output = model(**inputs)
-
-""",
-    "pipeline.py": """
-import os
-from transformers import (
-    TextClassificationPipeline,
-    BertForSequenceClassification,
-    BertConfig,
-    PreTrainedTokenizerFast,
-)
-
-tokenizer_file = os.path.join(os.path.dirname(__file__),"tokenizer.json")
-class MyPipeline(TextClassificationPipeline):
-    def __init__(self, **kwargs):
-        configuration = BertConfig()
-        tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_file)
-        super().__init__(
-            model=BertForSequenceClassification(configuration), tokenizer=tokenizer
-        )
-
-
-my_pipeline = MyPipeline()
-my_pipeline("This restaurant is awesome")
-""",
-    "activation.py": """
-import torch
-m = torch.nn.GELU()
-input = torch.randn(2)
-output = m(input)
-""",
-    "turnkey_parser.py": """
-from turnkeyml.parser import parse
-
-parsed_args = parse(["height", "width", "num_channels"])
-
-print(parsed_args)
-
-""",
-    "two_executions.py": """
-import torch
-import timm
-from turnkeyml.parser import parse
-
-# Creating model and set it to evaluation mode
-model = timm.create_model("mobilenetv2_035", pretrained=False)
-model.eval()
-
-# Creating inputs
-inputs1 = torch.rand((1, 3, 28, 28))
-inputs2 = torch.rand((1, 3, 224, 224))
-
-# Calling model
-model(inputs1)
-model(inputs2)
-model(inputs1)
-""",
-}
-minimal_tokenizer = """
-{
-  "version": "1.0",
-  "truncation": null,
-  "padding": null,
-  "added_tokens": [],
-  "normalizer": null,
-  "pre_tokenizer": null,
-  "post_processor": null,
-  "decoder": null,
-  "model": {
-    "type": "WordPiece",
-    "unk_token": "[UNK]",
-    "continuing_subword_prefix": "##",
-    "max_input_chars_per_word": 100,
-    "vocab": {
-      "[UNK]": 0
-    }
-  }
-}"""
-
-# Create a test directory
-cache_dir, corpus_dir = common.create_test_dir("analysis", test_scripts_dot_py)
-
-with open(os.path.join(corpus_dir, "tokenizer.json"), "w", encoding="utf") as f:
-    f.write(minimal_tokenizer)
-
-
 def cache_is_lean(cache_dir, build_name):
     files = list(glob.glob(f"{cache_dir}/{build_name}/**/*", recursive=True))
     is_lean = len([x for x in files if ".onnx" in x]) == 0
@@ -379,4 +257,125 @@ class Testing(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    # We generate a corpus on to the filesystem during the test
+    # to get around how weird bake tests are when it comes to
+    # filesystem access
+
+    test_scripts_dot_py = {
+        "linear_pytorch.py": """# labels: test_group::selftest license::mit framework::pytorch tags::selftest,small
+    import torch
+    import argparse
+
+    torch.manual_seed(0)
+
+    # Receive command line arg
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m",
+        "--my-arg",
+    )
+    args = parser.parse_args()
+    print(f"Received arg {args.my_arg}")
+
+    class LinearTestModel(torch.nn.Module):
+        def __init__(self, input_features, output_features):
+            super(LinearTestModel, self).__init__()
+            self.fc = torch.nn.Linear(input_features, output_features)
+
+        def forward(self, x):
+            output = self.fc(x)
+            return output
+
+    input_features = 10
+    output_features = 10
+
+    # Model and input configurations
+    model = LinearTestModel(input_features, output_features)
+    unexecuted_model = LinearTestModel(input_features+1, output_features)
+    inputs = {"x": torch.rand(input_features)}
+    output = model(**inputs)
+
+    """,
+        "pipeline.py": """
+    import os
+    from transformers import (
+        TextClassificationPipeline,
+        BertForSequenceClassification,
+        BertConfig,
+        PreTrainedTokenizerFast,
+    )
+
+    tokenizer_file = os.path.join(os.path.dirname(__file__),"tokenizer.json")
+    class MyPipeline(TextClassificationPipeline):
+        def __init__(self, **kwargs):
+            configuration = BertConfig()
+            tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_file)
+            super().__init__(
+                model=BertForSequenceClassification(configuration), tokenizer=tokenizer
+            )
+
+
+    my_pipeline = MyPipeline()
+    my_pipeline("This restaurant is awesome")
+    """,
+        "activation.py": """
+    import torch
+    m = torch.nn.GELU()
+    input = torch.randn(2)
+    output = m(input)
+    """,
+        "turnkey_parser.py": """
+    from turnkeyml.parser import parse
+
+    parsed_args = parse(["height", "width", "num_channels"])
+
+    print(parsed_args)
+
+    """,
+        "two_executions.py": """
+    import torch
+    import timm
+    from turnkeyml.parser import parse
+
+    # Creating model and set it to evaluation mode
+    model = timm.create_model("mobilenetv2_035", pretrained=False)
+    model.eval()
+
+    # Creating inputs
+    inputs1 = torch.rand((1, 3, 28, 28))
+    inputs2 = torch.rand((1, 3, 224, 224))
+
+    # Calling model
+    model(inputs1)
+    model(inputs2)
+    model(inputs1)
+    """,
+    }
+    minimal_tokenizer = """
+    {
+    "version": "1.0",
+    "truncation": null,
+    "padding": null,
+    "added_tokens": [],
+    "normalizer": null,
+    "pre_tokenizer": null,
+    "post_processor": null,
+    "decoder": null,
+    "model": {
+        "type": "WordPiece",
+        "unk_token": "[UNK]",
+        "continuing_subword_prefix": "##",
+        "max_input_chars_per_word": 100,
+        "vocab": {
+        "[UNK]": 0
+        }
+    }
+    }"""
+
+    # Create a test directory
+    cache_dir, corpus_dir = common.create_test_dir("analysis", test_scripts_dot_py)
+
+    with open(os.path.join(corpus_dir, "tokenizer.json"), "w", encoding="utf") as f:
+        f.write(minimal_tokenizer)
+
     unittest.main()

--- a/test/analysis.py
+++ b/test/analysis.py
@@ -31,6 +31,122 @@ except ImportError as e:
     )
 
 
+# We generate a corpus on to the filesystem during the test
+# to get around how weird bake tests are when it comes to
+# filesystem access
+
+test_scripts_dot_py = {
+    "linear_pytorch.py": """# labels: test_group::selftest license::mit framework::pytorch tags::selftest,small
+import torch
+import argparse
+
+torch.manual_seed(0)
+
+# Receive command line arg
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-m",
+    "--my-arg",
+)
+args = parser.parse_args()
+print(f"Received arg {args.my_arg}")
+
+class LinearTestModel(torch.nn.Module):
+    def __init__(self, input_features, output_features):
+        super(LinearTestModel, self).__init__()
+        self.fc = torch.nn.Linear(input_features, output_features)
+
+    def forward(self, x):
+        output = self.fc(x)
+        return output
+
+input_features = 10
+output_features = 10
+
+# Model and input configurations
+model = LinearTestModel(input_features, output_features)
+unexecuted_model = LinearTestModel(input_features+1, output_features)
+inputs = {"x": torch.rand(input_features)}
+output = model(**inputs)
+
+""",
+    "pipeline.py": """
+import os
+from transformers import (
+    TextClassificationPipeline,
+    BertForSequenceClassification,
+    BertConfig,
+    PreTrainedTokenizerFast,
+)
+
+tokenizer_file = os.path.join(os.path.dirname(__file__),"tokenizer.json")
+class MyPipeline(TextClassificationPipeline):
+    def __init__(self, **kwargs):
+        configuration = BertConfig()
+        tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_file)
+        super().__init__(
+            model=BertForSequenceClassification(configuration), tokenizer=tokenizer
+        )
+
+
+my_pipeline = MyPipeline()
+my_pipeline("This restaurant is awesome")
+""",
+    "activation.py": """
+import torch
+m = torch.nn.GELU()
+input = torch.randn(2)
+output = m(input)
+""",
+    "turnkey_parser.py": """
+from turnkeyml.parser import parse
+
+parsed_args = parse(["height", "width", "num_channels"])
+
+print(parsed_args)
+
+""",
+    "two_executions.py": """
+import torch
+import timm
+from turnkeyml.parser import parse
+
+# Creating model and set it to evaluation mode
+model = timm.create_model("mobilenetv2_035", pretrained=False)
+model.eval()
+
+# Creating inputs
+inputs1 = torch.rand((1, 3, 28, 28))
+inputs2 = torch.rand((1, 3, 224, 224))
+
+# Calling model
+model(inputs1)
+model(inputs2)
+model(inputs1)
+""",
+}
+minimal_tokenizer = """
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordPiece",
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": "##",
+    "max_input_chars_per_word": 100,
+    "vocab": {
+      "[UNK]": 0
+    }
+  }
+}"""
+
+
 def cache_is_lean(cache_dir, build_name):
     files = list(glob.glob(f"{cache_dir}/{build_name}/**/*", recursive=True))
     is_lean = len([x for x in files if ".onnx" in x]) == 0
@@ -257,121 +373,6 @@ class Testing(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # We generate a corpus on to the filesystem during the test
-    # to get around how weird bake tests are when it comes to
-    # filesystem access
-
-    test_scripts_dot_py = {
-        "linear_pytorch.py": """# labels: test_group::selftest license::mit framework::pytorch tags::selftest,small
-    import torch
-    import argparse
-
-    torch.manual_seed(0)
-
-    # Receive command line arg
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-m",
-        "--my-arg",
-    )
-    args = parser.parse_args()
-    print(f"Received arg {args.my_arg}")
-
-    class LinearTestModel(torch.nn.Module):
-        def __init__(self, input_features, output_features):
-            super(LinearTestModel, self).__init__()
-            self.fc = torch.nn.Linear(input_features, output_features)
-
-        def forward(self, x):
-            output = self.fc(x)
-            return output
-
-    input_features = 10
-    output_features = 10
-
-    # Model and input configurations
-    model = LinearTestModel(input_features, output_features)
-    unexecuted_model = LinearTestModel(input_features+1, output_features)
-    inputs = {"x": torch.rand(input_features)}
-    output = model(**inputs)
-
-    """,
-        "pipeline.py": """
-    import os
-    from transformers import (
-        TextClassificationPipeline,
-        BertForSequenceClassification,
-        BertConfig,
-        PreTrainedTokenizerFast,
-    )
-
-    tokenizer_file = os.path.join(os.path.dirname(__file__),"tokenizer.json")
-    class MyPipeline(TextClassificationPipeline):
-        def __init__(self, **kwargs):
-            configuration = BertConfig()
-            tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_file)
-            super().__init__(
-                model=BertForSequenceClassification(configuration), tokenizer=tokenizer
-            )
-
-
-    my_pipeline = MyPipeline()
-    my_pipeline("This restaurant is awesome")
-    """,
-        "activation.py": """
-    import torch
-    m = torch.nn.GELU()
-    input = torch.randn(2)
-    output = m(input)
-    """,
-        "turnkey_parser.py": """
-    from turnkeyml.parser import parse
-
-    parsed_args = parse(["height", "width", "num_channels"])
-
-    print(parsed_args)
-
-    """,
-        "two_executions.py": """
-    import torch
-    import timm
-    from turnkeyml.parser import parse
-
-    # Creating model and set it to evaluation mode
-    model = timm.create_model("mobilenetv2_035", pretrained=False)
-    model.eval()
-
-    # Creating inputs
-    inputs1 = torch.rand((1, 3, 28, 28))
-    inputs2 = torch.rand((1, 3, 224, 224))
-
-    # Calling model
-    model(inputs1)
-    model(inputs2)
-    model(inputs1)
-    """,
-    }
-    minimal_tokenizer = """
-    {
-    "version": "1.0",
-    "truncation": null,
-    "padding": null,
-    "added_tokens": [],
-    "normalizer": null,
-    "pre_tokenizer": null,
-    "post_processor": null,
-    "decoder": null,
-    "model": {
-        "type": "WordPiece",
-        "unk_token": "[UNK]",
-        "continuing_subword_prefix": "##",
-        "max_input_chars_per_word": 100,
-        "vocab": {
-        "[UNK]": 0
-        }
-    }
-    }"""
-
     # Create a test directory
     cache_dir, corpus_dir = common.create_test_dir("analysis", test_scripts_dot_py)
 

--- a/test/cli.py
+++ b/test/cli.py
@@ -997,64 +997,65 @@ if __name__ == "__main__":
 
     extras_dot_py = {
         "compiled.py": """
-    # labels: name::linear author::selftest test_group::selftest task::test
-    import torch
+# labels: name::linear author::selftest test_group::selftest task::test
+import torch
 
-    torch.manual_seed(0)
-
-
-    class LinearTestModel(torch.nn.Module):
-        def __init__(self, input_features, output_features):
-            super(LinearTestModel, self).__init__()
-            self.fc = torch.nn.Linear(input_features, output_features)
-
-        def forward(self, x):
-            output = self.fc(x)
-            return output
+torch.manual_seed(0)
 
 
-    input_features = 10
-    output_features = 10
+class LinearTestModel(torch.nn.Module):
+    def __init__(self, input_features, output_features):
+        super(LinearTestModel, self).__init__()
+        self.fc = torch.nn.Linear(input_features, output_features)
 
-    # Compiled model
-    model = LinearTestModel(input_features, output_features)
-    model = torch.compile(model)
-    inputs = {"x": torch.rand(input_features)}
-    model(**inputs)
+    def forward(self, x):
+        output = self.fc(x)
+        return output
 
-    # Non-compiled model
-    model2 = LinearTestModel(input_features * 2, output_features)
-    inputs2 = {"x": torch.rand(input_features * 2)}
-    model2(**inputs2)
+
+input_features = 10
+output_features = 10
+
+# Compiled model
+model = LinearTestModel(input_features, output_features)
+model = torch.compile(model)
+inputs = {"x": torch.rand(input_features)}
+model(**inputs)
+
+# Non-compiled model
+model2 = LinearTestModel(input_features * 2, output_features)
+inputs2 = {"x": torch.rand(input_features * 2)}
+model2(**inputs2)
     """,
         "selected_models.txt": f"""
     {os.path.join(corpus_dir,"linear.py")}
     {os.path.join(corpus_dir,"linear2.py")}
     """,
-        "timeout.py": """# labels: name::timeout author::turnkey license::mit test_group::a task::test
-    import torch
+        "timeout.py": """
+# labels: name::timeout author::turnkey license::mit test_group::a task::test
+import torch
 
-    torch.manual_seed(0)
-
-
-    class LinearTestModel(torch.nn.Module):
-        def __init__(self, input_features, output_features):
-            super(LinearTestModel, self).__init__()
-            self.fc = torch.nn.Linear(input_features, output_features)
-
-        def forward(self, x):
-            output = self.fc(x)
-            return output
+torch.manual_seed(0)
 
 
-    input_features = 500000
-    output_features = 1000
+class LinearTestModel(torch.nn.Module):
+    def __init__(self, input_features, output_features):
+        super(LinearTestModel, self).__init__()
+        self.fc = torch.nn.Linear(input_features, output_features)
 
-    # Model and input configurations
-    model = LinearTestModel(input_features, output_features)
-    inputs = {"x": torch.rand(input_features)}
+    def forward(self, x):
+        output = self.fc(x)
+        return output
 
-    output = model(**inputs)
+
+input_features = 500000
+output_features = 1000
+
+# Model and input configurations
+model = LinearTestModel(input_features, output_features)
+inputs = {"x": torch.rand(input_features)}
+
+output = model(**inputs)
 
     """,
     }

--- a/test/gpu.py
+++ b/test/gpu.py
@@ -41,29 +41,29 @@ class Testing(unittest.TestCase):
 if __name__ == "__main__":
     test_scripts_dot_py = {
         "linear.py": """# labels: name::linear author::turnkey license::mit test_group::a
-    import torch
+import torch
 
-    torch.manual_seed(0)
-
-
-    class LinearTestModel(torch.nn.Module):
-        def __init__(self, input_features, output_features):
-            super(LinearTestModel, self).__init__()
-            self.fc = torch.nn.Linear(input_features, output_features)
-
-        def forward(self, x):
-            output = self.fc(x)
-            return output
+torch.manual_seed(0)
 
 
-    input_features = 10
-    output_features = 10
+class LinearTestModel(torch.nn.Module):
+    def __init__(self, input_features, output_features):
+        super(LinearTestModel, self).__init__()
+        self.fc = torch.nn.Linear(input_features, output_features)
 
-    # Model and input configurations
-    model = LinearTestModel(input_features, output_features)
-    inputs = {"x": torch.rand(input_features)}
+    def forward(self, x):
+        output = self.fc(x)
+        return output
 
-    output = model(**inputs)
+
+input_features = 10
+output_features = 10
+
+# Model and input configurations
+model = LinearTestModel(input_features, output_features)
+inputs = {"x": torch.rand(input_features)}
+
+output = model(**inputs)
 
     """
     }

--- a/test/gpu.py
+++ b/test/gpu.py
@@ -11,56 +11,6 @@ from turnkeyml.cli.cli import main as turnkeycli
 import turnkeyml.common.filesystem as filesystem
 from cli import assert_success_of_builds, flatten
 
-test_scripts_dot_py = {
-    "linear.py": """# labels: name::linear author::turnkey license::mit test_group::a
-import torch
-
-torch.manual_seed(0)
-
-
-class LinearTestModel(torch.nn.Module):
-    def __init__(self, input_features, output_features):
-        super(LinearTestModel, self).__init__()
-        self.fc = torch.nn.Linear(input_features, output_features)
-
-    def forward(self, x):
-        output = self.fc(x)
-        return output
-
-
-input_features = 10
-output_features = 10
-
-# Model and input configurations
-model = LinearTestModel(input_features, output_features)
-inputs = {"x": torch.rand(input_features)}
-
-output = model(**inputs)
-
-"""
-}
-
-
-# Create a test directory and make it the CWD
-test_dir = os.path.join(os.path.dirname(__file__), "generated", "gpu_test_dir")
-cache_dir = os.path.join(os.path.dirname(__file__), "generated", "cache-dir")
-if os.path.isdir(test_dir):
-    shutil.rmtree(test_dir)
-if os.path.isdir(cache_dir):
-    shutil.rmtree(cache_dir)
-os.makedirs(test_dir)
-os.chdir(test_dir)
-
-corpus_dir = os.path.join(os.getcwd(), "test_corpus")
-extras_dir = os.path.join(corpus_dir, "extras")
-os.makedirs(extras_dir, exist_ok=True)
-
-for key, value in test_scripts_dot_py.items():
-    model_path = os.path.join(corpus_dir, key)
-
-    with open(model_path, "w", encoding="utf") as f:
-        f.write(value)
-
 
 class Testing(unittest.TestCase):
     def setUp(self) -> None:
@@ -89,4 +39,53 @@ class Testing(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    test_scripts_dot_py = {
+        "linear.py": """# labels: name::linear author::turnkey license::mit test_group::a
+    import torch
+
+    torch.manual_seed(0)
+
+
+    class LinearTestModel(torch.nn.Module):
+        def __init__(self, input_features, output_features):
+            super(LinearTestModel, self).__init__()
+            self.fc = torch.nn.Linear(input_features, output_features)
+
+        def forward(self, x):
+            output = self.fc(x)
+            return output
+
+
+    input_features = 10
+    output_features = 10
+
+    # Model and input configurations
+    model = LinearTestModel(input_features, output_features)
+    inputs = {"x": torch.rand(input_features)}
+
+    output = model(**inputs)
+
+    """
+    }
+
+    # Create a test directory and make it the CWD
+    test_dir = os.path.join(os.path.dirname(__file__), "generated", "gpu_test_dir")
+    cache_dir = os.path.join(os.path.dirname(__file__), "generated", "cache-dir")
+    if os.path.isdir(test_dir):
+        shutil.rmtree(test_dir)
+    if os.path.isdir(cache_dir):
+        shutil.rmtree(cache_dir)
+    os.makedirs(test_dir)
+    os.chdir(test_dir)
+
+    corpus_dir = os.path.join(os.getcwd(), "test_corpus")
+    extras_dir = os.path.join(corpus_dir, "extras")
+    os.makedirs(extras_dir, exist_ok=True)
+
+    for key, value in test_scripts_dot_py.items():
+        model_path = os.path.join(corpus_dir, key)
+
+        with open(model_path, "w", encoding="utf") as f:
+            f.write(value)
+
     unittest.main()

--- a/test/plugins.py
+++ b/test/plugins.py
@@ -11,9 +11,6 @@ import turnkeyml.common.filesystem as filesystem
 import turnkeyml.common.build as build
 from helpers import common
 
-# Create a cache directory a directory with test models
-cache_dir, corpus_dir = common.create_test_dir("plugins")
-
 
 class Testing(unittest.TestCase):
     def setUp(self) -> None:
@@ -52,4 +49,7 @@ class Testing(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    # Create a cache directory a directory with test models
+    cache_dir, corpus_dir = common.create_test_dir("plugins")
+
     unittest.main()


### PR DESCRIPTION
Closes #19 by adding a new command, `turnkey cache benchmark`.

Note that this command is temporary, and will be replaced by `turnkey benchmark BUILD_DIRS` soon (see #115).

```
(tklocal) PS C:\work> turnkey cache benchmark -h
usage: turnkey cache benchmark [-h] [-d CACHE_DIR] [--all] [--skip {attempted,failed,successful,none}]
                               [--timeout TIMEOUT] [--runtime {ort,trt,torch-eager,torch-compiled,vitisep}]    
                               [--iterations ITERATIONS] [--rt-args [RT_ARGS [RT_ARGS ...]]]
                               [build_names]

positional arguments:
  build_names           Name of the specific build(s) to be benchmarked, within the cache directory

optional arguments:
  -h, --help            show this help message and exit
  -d CACHE_DIR, --cache-dir CACHE_DIR
                        Search path for builds (defaults to C:\Users\jefowers/.cache/turnkey)
  --all                 Benchmark all builds in the cache directory
  --skip {attempted,failed,successful,none}
                        Sets the policy for skipping benchmark attempts (defaults to attempted).`attempted`    
                        means to skip any previously-attempted benchmark, whether it succeeded or
                        failed.`failed` skips benchmarks that have already failed once.`successful` skips      
                        benchmarks that have already succeeded.`none` will attempt all benchmarks, regardless  
                        of whether they were previously attempted.
  --timeout TIMEOUT     Benchmark timeout, in seconds, after which each benchmark will be canceled
                        (default: no timeout).
  --runtime {ort,trt,torch-eager,torch-compiled,vitisep}
                        Software runtime that will be used to collect the benchmark. Must be compatible with   
                        the device chosen for the build. If this argument is not set, the default runtime of   
                        the selected device will be used.
  --iterations ITERATIONS
                        Number of execution iterations of the model to capture the benchmarking performance    
                        (e.g., mean latency)
  --rt-args [RT_ARGS [RT_ARGS ...]]
                        Optional arguments provided to the runtime being used
```

# Design Considerations

- There is a fair amount of overlap in logic between the benchmarking capability in `turnkeyml.analyze.script.explore_invocation()` and the new `benchmark_build()` function.
  - If left as-is, we will need to keep these functions in sync, which may be annoying and error-prone
  - We _could_ refactor so that there is only one code path for benchmarking. However, that would involve substantially moving functionality around and it will delay this PR and other work.
- `turnkey cache benchmark` always runs its benchmarks in process isolation mode, with no option to turn that off. I did it this way since the purpose of the function is mass-benchmarking, which should always happen in isolated processes.

# Demo

## Basic Operation

On a cache with 3 `efficientnet*` builds:

```
(tklocal) PS C:\work\turnkeyml\models\timm> turnkey cache benchmark --all --skip none
  0%|                                                                                   | 0/3 [00:00<?, ?it/s]
Info: Attempting to benchmark: efficientnet_b0_timm_94d604de

Info: Performance of build efficientnet_b0_timm_94d604de on AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics (ort v1.15.1) is:
        Mean Latency: 6.168 milliseconds (ms)
        Throughput: 162.1 inferences per second (IPS)


Woohoo! Done benchmarking: efficientnet_b0_timm_94d604de
 33%|█████████████████████████                                                  | 1/3 [00:23<00:47, 23.85s/it]
Info: Attempting to benchmark: efficientnet_b1_timm_47686f1f

Info: Performance of build efficientnet_b1_timm_47686f1f on AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics (ort v1.15.1) is:
        Mean Latency: 10.051 milliseconds (ms)
        Throughput: 99.5 inferences per second (IPS)


Woohoo! Done benchmarking: efficientnet_b1_timm_47686f1f
 67%|██████████████████████████████████████████████████                         | 2/3 [00:48<00:24, 24.53s/it]
Info: Attempting to benchmark: efficientnet_b2_timm_72dbc375

Info: Performance of build efficientnet_b2_timm_72dbc375 on AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics (ort v1.15.1) is:
        Mean Latency: 15.435 milliseconds (ms)
        Throughput: 64.8 inferences per second (IPS)


Woohoo! Done benchmarking: efficientnet_b2_timm_72dbc375
100%|███████████████████████████████████████████████████████████████████████████| 3/3 [01:14<00:00, 24.82s/it]
```

## HardwareError Raised

If benchmarking a build results in a HardwareError (e.g., computer needs a restart), that build will be marked as `benchmark_status: error` and `error_log` will get content like this:

```
evaluations:
  3b643be8:
    benchmark_status: error
    build_name: efficientnet_b0_timm_94d604de
    build_status: successful
    device: AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics
    device_type: x86
    error_log: "Traceback (most recent call last):\n  File \"C:\\work\\turnkeyml\\\
      src\\turnkeyml\\run\\benchmark_build.py\", line 29, in run\n    multiprocessing.Process.run(self)\n\
      \  File \"C:\\Users\\jefowers\\AppData\\Local\\miniconda3\\envs\\tklocal\\lib\\\
      multiprocessing\\process.py\", line 108, in run\n    self._target(*self._args,\
      \ **self._kwargs)\n  File \"C:\\work\\turnkeyml\\src\\turnkeyml\\run\\benchmark_build.py\"\
      , line 72, in benchmark_build\n    raise exp.HardwareError(\nturnkeyml.common.exceptions.HardwareError:\
      \ You have the correct driver installed (12121). However, Microsoft PnP Utility\
      \ shows that your device has a problem. Please check Device Manager for\
      \ more information about this issue.\n\n\n"
```