### PR TITLE
Capture TorchRT benchmarking outputs into a log file

### DIFF
--- a/src/turnkeyml/run/basert.py
+++ b/src/turnkeyml/run/basert.py
@@ -79,6 +79,9 @@ class BaseRT(ABC):
         self.logfile_path = os.path.join(
             self.local_output_dir, f"{runtime}_benchmark_log.txt"
         )
+        self.compile_logfile_path = os.path.join(
+            self.local_output_dir, f"{runtime}_compile_log.txt"
+        )
 
         # Validate runtime is supported
         if runtime not in runtimes_supported:


### PR DESCRIPTION
This PR captures all stdout/stderr from TorchRT benchmarks into a log file. This behavior is similar to how OnnxRT and TensorRT handle logging.