### PR TITLE
Set benchmark timeout

### DIFF
--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -519,9 +519,9 @@ def main():
     cache_benchmark_parser.add_argument(
         "--timeout",
         type=int,
-        default=None,
+        default=1800,
         help="Benchmark timeout, in seconds, after which each benchmark will be canceled "
-        "(default: no timeout).",
+        "(default: 30min).",
     )
 
     cache_benchmark_parser.add_argument(


### PR DESCRIPTION
Set the benchmark timeout default to 30min.