### PR TITLE
Fix hang on OEM info read

### DIFF
--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -558,7 +558,7 @@ def get_system_info():
             try:
                 oem_info = (
                     subprocess.check_output(
-                        "sudo dmidecode -s system-product-name",
+                        "sudo -n dmidecode -s system-product-name",
                         shell=True,
                     )
                     .decode()
@@ -566,6 +566,9 @@ def get_system_info():
                     .replace("\n", " ")
                 )
                 info_dict["OEM System"] = oem_info
+            except subprocess.CalledProcessError:
+                # This catches the case where sudo requires a password
+                info_dict["OEM System"] = "Unable to get oem info - password required"
             except Exception as e:  # pylint: disable=broad-except
                 info_dict["Error OEM System"] = str(e)
 


### PR DESCRIPTION
This PR closes #127 by using non-interactive sudo.
This will make a best effort attempt at reading the oem info from the system under test. If password is enabled on the system, skips reading oem info. 