### PR TITLE
Save the exception into error_log when the subprocess is killed

### DIFF
--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -355,6 +355,7 @@ def run_turnkey(
                     and evaluation_id
                 ):
                     try:
+
                         # Amend the stats with a specific function status if possible
                         if isinstance(e, subprocess.TimeoutExpired):
                             evaluation_status = build.FunctionStatus.TIMEOUT
@@ -374,6 +375,8 @@ def run_turnkey(
                             ):
                                 stats.save_model_eval_stat(key, evaluation_status.value)
 
+                        # Save the exception into the error log stat
+                        stats.save_model_eval_stat(filesystem.Keys.ERROR_LOG, str(e))
                     except Exception as stats_exception:  # pylint: disable=broad-except
                         printing.log_info(
                             "Stats file found, but unable to perform cleanup due to "

--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -355,7 +355,6 @@ def run_turnkey(
                     and evaluation_id
                 ):
                     try:
-
                         # Amend the stats with a specific function status if possible
                         if isinstance(e, subprocess.TimeoutExpired):
                             evaluation_status = build.FunctionStatus.TIMEOUT
@@ -377,6 +376,7 @@ def run_turnkey(
 
                         # Save the exception into the error log stat
                         stats.save_model_eval_stat(filesystem.Keys.ERROR_LOG, str(e))
+
                     except Exception as stats_exception:  # pylint: disable=broad-except
                         printing.log_info(
                             "Stats file found, but unable to perform cleanup due to "


### PR DESCRIPTION
Closes #136 by saving the exception message to the stats/report when a process isolation subprocess is killed.

# Demo

## Process Terminated by Task Manager on Windows

```
class: BertModel
evaluations:
  eb608bba:
    benchmark_status: not_started
    build_status: killed
    device_type: x86
    error_log: Command 'turnkey benchmark C:\work\turnkeyml\models\transformers\bert_large.py  --rebuild="if_needed"
      --device="x86" --runtime="ort" --iterations="100"   --max-depth="0"  --verbosity="static"
      --cache-dir="C:\Users\jefowers/.cache/turnkey"' returned non-zero exit status
      1.
```

## Process Terminated by OOM Error on Linux

```
class: BertModel
evaluations:
  2354c169:
    benchmark_status: not_started
    build_status: killed
    device_type: x86
    error_log: 'Command ''[''turnkey'', ''benchmark'', ''/home/jefowers/turnkeyml/models/transformers/bert_large.py'',
      ''--rebuild=if_needed'', ''--device=x86'', ''--runtime=ort'', ''--iterations=100'',
      ''--max-depth=0'', ''--verbosity=static'', ''--cache-dir=/home/jefowers/.cache/turnkey'']''
      died with <Signals.SIGKILL: 9>.'
```