### PR TITLE
Update the State class

### DIFF
--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
@@ -57,7 +57,7 @@ class CombinedExampleRT(BaseRT):
         pass
 
     def benchmark(self):
-        state = build.load_state(self.cache_dir, self.build_name)
+        state = fs.load_state(self.cache_dir, self.build_name)
         per_iteration_latency = []
         sess_options = ort.SessionOptions()
         sess_options.graph_optimization_level = (

--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
@@ -5,10 +5,9 @@ import onnxruntime as ort
 import numpy as np
 from turnkeyml.run.basert import BaseRT
 import turnkeyml.common.exceptions as exp
-import turnkeyml.common.build as build
+import turnkeyml.common.filesystem as fs
 from turnkeyml.run.onnxrt.within_conda import dummy_inputs
 from turnkeyml.common.performance import MeasuredPerformance
-from turnkeyml.common.filesystem import Stats
 
 
 combined_rt_name = "example-combined-rt"
@@ -19,7 +18,7 @@ class CombinedExampleRT(BaseRT):
         self,
         cache_dir: str,
         build_name: str,
-        stats: Stats,
+        stats: fs.Stats,
         iterations: int,
         device_type: str,
         runtime: str = combined_rt_name,

--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/runtime.py
@@ -63,7 +63,7 @@ class CombinedExampleRT(BaseRT):
         sess_options.graph_optimization_level = (
             ort.GraphOptimizationLevel.ORT_ENABLE_ALL
         )
-        onnx_session = ort.InferenceSession(state.results[0], sess_options)
+        onnx_session = ort.InferenceSession(state.results, sess_options)
         sess_input = onnx_session.get_inputs()
         input_feed = dummy_inputs(sess_input)
         output_name = onnx_session.get_outputs()[0].name

--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
@@ -17,7 +17,7 @@ class CombinedExampleStage(Stage):
             monitor_message="Special step expected by CombinedExampleRT",
         )
 
-    def fire(self, state: build.State):
+    def fire(self, state: fs.State):
         return state
 
 

--- a/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
+++ b/examples/cli/plugins/example_combined/turnkeyml_plugin_example_combined/sequence.py
@@ -1,5 +1,5 @@
 from turnkeyml.build.stage import Sequence, Stage
-import turnkeyml.common.build as build
+import turnkeyml.common.filesystem as fs
 import turnkeyml.build.export as export
 
 combined_seq_name = "example-combined-seq"

--- a/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
+++ b/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
@@ -13,7 +13,7 @@ After you install the plugin, you can tell `turnkey` to use this sequence with:
 """
 
 from turnkeyml.build.stage import Sequence, Stage
-import turnkeyml.common.build as build
+import turnkeyml.common.filesystem as fs
 import turnkeyml.build.export as export
 
 

--- a/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
+++ b/examples/cli/plugins/example_seq/turnkeyml_plugin_example_seq/sequence.py
@@ -33,7 +33,7 @@ class ExampleStage(Stage):
             monitor_message="Teaching by example",
         )
 
-    def fire(self, state: build.State):
+    def fire(self, state: fs.State):
         return state
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
         "pandas>=1.5.3",
         "fasteners",
         "GitPython>=3.1.40",
+        # Necessary until upstream packages account for the breaking
+        # change to numpy
+        "numpy<2.0.0",
         "psutil",
     ],
     classifiers=[],

--- a/src/turnkeyml/__init__.py
+++ b/src/turnkeyml/__init__.py
@@ -3,4 +3,4 @@ from turnkeyml.version import __version__
 from .files_api import benchmark_files
 from .cli.cli import main as turnkeycli
 from .build_api import build_model
-from .common.build import load_state
+from .common.filesystem import load_state

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -415,7 +415,7 @@ def explore_invocation(
                 fs.Keys.BUILD_STATUS, build.FunctionStatus.SUCCESSFUL
             )
 
-            model_to_benchmark = build_state.results[0]
+            model_to_benchmark = build_state.results
 
             # Analyze the onnx file (if any) and save statistics
             analyze_model.analyze_onnx(

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -526,6 +526,8 @@ def explore_invocation(
 
         _store_traceback(invocation_info)
 
+        raise e
+
     finally:
         # Ensure that stdout/stderr is not being forwarded before updating status
         status.stop_logger_forward()

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -522,8 +522,6 @@ def explore_invocation(
 
         _store_traceback(invocation_info)
 
-        raise e
-
     finally:
         # Ensure that stdout/stderr is not being forwarded before updating status
         status.stop_logger_forward()

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -181,16 +181,12 @@ def set_status_on_exception(
     # whether the exception was thrown during build or benchmark
     # We also take into account whether a build was requested
     if build_required and not build_state:
-        stats.save_model_eval_stat(
-            fs.Keys.BUILD_STATUS, build.FunctionStatus.ERROR.value
-        )
+        stats.save_model_eval_stat(fs.Keys.BUILD_STATUS, build.FunctionStatus.ERROR)
 
         # NOTE: The log file for the failed build stage should have
         # already been saved to stats
     else:
-        stats.save_model_eval_stat(
-            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.ERROR.value
-        )
+        stats.save_model_eval_stat(fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.ERROR)
 
         # Also save the benchmark log file to the stats
         stats.save_eval_error_log(benchmark_logfile_path)
@@ -376,12 +372,12 @@ def explore_invocation(
     # that action is part of the evaluation
     if runtime_info["build_required"]:
         stats.save_model_eval_stat(
-            fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_STARTED.value
+            fs.Keys.BUILD_STATUS, build.FunctionStatus.NOT_STARTED
         )
 
     if Action.BENCHMARK in tracer_args.actions:
         stats.save_model_eval_stat(
-            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED.value
+            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED
         )
 
         # Save the device name that will be used for the benchmark
@@ -400,7 +396,7 @@ def explore_invocation(
             # If a concluded build still has a status of "running", this means
             # there was an uncaught exception.
             stats.save_model_eval_stat(
-                fs.Keys.BUILD_STATUS, build.FunctionStatus.INCOMPLETE.value
+                fs.Keys.BUILD_STATUS, build.FunctionStatus.INCOMPLETE
             )
 
             build_state = build_model(
@@ -416,7 +412,7 @@ def explore_invocation(
             )
 
             stats.save_model_eval_stat(
-                fs.Keys.BUILD_STATUS, build.FunctionStatus.SUCCESSFUL.value
+                fs.Keys.BUILD_STATUS, build.FunctionStatus.SUCCESSFUL
             )
 
             model_to_benchmark = build_state.results[0]
@@ -438,7 +434,7 @@ def explore_invocation(
                 rt_args_to_use = tracer_args.rt_args
 
             stats.save_model_eval_stat(
-                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.INCOMPLETE.value
+                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.INCOMPLETE
             )
 
             runtime_handle = runtime_info["RuntimeClass"](
@@ -462,7 +458,7 @@ def explore_invocation(
                 )
 
             stats.save_model_eval_stat(
-                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL.value
+                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL
             )
 
             invocation_info.status_message = "Model successfully benchmarked!"

--- a/src/turnkeyml/analyze/script.py
+++ b/src/turnkeyml/analyze/script.py
@@ -169,7 +169,7 @@ def _store_traceback(invocation_info: status.UniqueInvocationInfo):
 
 def set_status_on_exception(
     build_required: bool,
-    build_state: build.State,
+    build_state: fs.State,
     stats: fs.Stats,
     benchmark_logfile_path: str,
 ):

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -392,7 +392,7 @@ class OptimizeOnnxModel(stage.Stage):
         )
 
     def fire(self, state: fs.State):
-        input_onnx = state.intermediate_results[0]
+        input_onnx = state.intermediate_results
         output_path = opt_onnx_file(state)
 
         # Perform some basic optimizations on the model to remove shape related
@@ -455,7 +455,7 @@ class ConvertOnnxToFp16(stage.Stage):
         )
 
     def fire(self, state: fs.State):
-        input_onnx = state.intermediate_results[0]
+        input_onnx = state.intermediate_results
 
         # Convert the model to FP16
         # Some ops will not be converted to fp16 because they are in a block list

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -184,7 +184,7 @@ class ReceiveOnnxModel(stage.Stage):
         fail_msg = "\tFailed receiving ONNX Model"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = [output_path]
+            state.intermediate_results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(
@@ -354,7 +354,7 @@ class ExportPytorchModel(stage.Stage):
         fail_msg = "\tFailed exporting model to ONNX"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = [output_path]
+            state.intermediate_results = output_path
 
             stats.save_model_eval_stat(
                 fs.Keys.ONNX_FILE,
@@ -417,7 +417,7 @@ class OptimizeOnnxModel(stage.Stage):
         fail_msg = "\tFailed optimizing ONNX model"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = [output_path]
+            state.intermediate_results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(
@@ -521,7 +521,7 @@ class ConvertOnnxToFp16(stage.Stage):
         fail_msg = "\tFailed converting ONNX model to fp16"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = [output_path]
+            state.intermediate_results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(

--- a/src/turnkeyml/build/ignition.py
+++ b/src/turnkeyml/build/ignition.py
@@ -131,47 +131,52 @@ def validate_cached_model(
             changed_args.append((key, vars(new_state)[key], vars(cached_state)[key]))
 
     # Show an error if the model changed
+    build_conditions_changed = (
+        model_changed
+        or input_shapes_changed
+        or input_dtypes_changed
+        or len(changed_args) > 0
+    )
+    if build_conditions_changed:
 
-    # Show an error if build_name is not specified for different models on the same script
-    if cached_state.uid == build.unique_id():
-        msg = (
-            "You are building multiple different models in the same script "
-            "without specifying a unique build_model(..., build_name=) for each build."
-        )
-        result.append(msg)
-
-    if model_changed:
-        msg = (
-            f'Model "{new_state.build_name}" changed since the last time it was built.'
-        )
-        result.append(msg)
-
-    if input_shapes_changed:
-        input_shapes, _ = build.get_shapes_and_dtypes(inputs)
-        msg = (
-            f'Input shape of model "{new_state.build_name}" changed from '
-            f"{cached_state.expected_input_shapes} to {input_shapes} "
-            f"since the last time it was built."
-        )
-        result.append(msg)
-
-    if input_dtypes_changed:
-        _, input_dtypes = build.get_shapes_and_dtypes(inputs)
-        msg = (
-            f'Input data type of model "{new_state.build_name}" changed from '
-            f"{cached_state.expected_input_dtypes} to {input_dtypes} "
-            f"since the last time it was built."
-        )
-        result.append(msg)
-
-    if len(changed_args) > 0:
-        for key_name, current_arg, previous_arg in changed_args:
+        # Show an error if build_name is not specified for different models on the same script
+        if cached_state.uid == new_state.unique_id():
             msg = (
-                f'build_model() argument "{key_name}" for build '
-                f"{new_state.build_name} changed from "
-                f"{previous_arg} to {current_arg} since the last build."
+                "You are building multiple different models in the same script "
+                "without specifying a unique build_model(..., build_name=) for each build."
             )
             result.append(msg)
+
+        if model_changed:
+            msg = f'Model "{new_state.build_name}" changed since the last time it was built.'
+            result.append(msg)
+
+        if input_shapes_changed:
+            input_shapes, _ = build.get_shapes_and_dtypes(inputs)
+            msg = (
+                f'Input shape of model "{new_state.build_name}" changed from '
+                f"{cached_state.expected_input_shapes} to {input_shapes} "
+                f"since the last time it was built."
+            )
+            result.append(msg)
+
+        if input_dtypes_changed:
+            _, input_dtypes = build.get_shapes_and_dtypes(inputs)
+            msg = (
+                f'Input data type of model "{new_state.build_name}" changed from '
+                f"{cached_state.expected_input_dtypes} to {input_dtypes} "
+                f"since the last time it was built."
+            )
+            result.append(msg)
+
+        if len(changed_args) > 0:
+            for key_name, current_arg, previous_arg in changed_args:
+                msg = (
+                    f'build_model() argument "{key_name}" for build '
+                    f"{new_state.build_name} changed from "
+                    f"{previous_arg} to {current_arg} since the last build."
+                )
+                result.append(msg)
 
     return result
 

--- a/src/turnkeyml/build/ignition.py
+++ b/src/turnkeyml/build/ignition.py
@@ -86,7 +86,8 @@ def validate_cached_model(
             (
                 f"Your build {cached_state.build_name} was previously built against "
                 f"turnkey version {cached_state.turnkey_version}, "
-                f"however you are now using turnkey version {turnkey_version}. The previous build is "
+                f"however you are now using turnkey version {turnkey_version}. "
+                "The previous build is "
                 f"incompatible with this version of turnkey, as indicated by the {out_of_date} "
                 "version number changing. See **docs/versioning.md** for details."
             )

--- a/src/turnkeyml/build/ignition.py
+++ b/src/turnkeyml/build/ignition.py
@@ -1,11 +1,11 @@
-from typing import Optional, List, Tuple, Union, Dict, Any, Type, Callable
+from typing import Optional, List, Tuple, Union, Dict, Any
 import sys
 import os
 import copy
 import torch
 import onnx
 import turnkeyml.common.build as build
-import turnkeyml.common.filesystem as filesystem
+import turnkeyml.common.filesystem as fs
 import turnkeyml.common.exceptions as exp
 import turnkeyml.common.printing as printing
 import turnkeyml.build.onnx_helpers as onnx_helpers
@@ -16,13 +16,13 @@ import turnkeyml.build.sequences as sequences
 from turnkeyml.version import __version__ as turnkey_version
 
 
-def lock_config(
+def initialize_state(
     model: build.UnionValidModelInstanceTypes,
     build_name: Optional[str] = None,
     sequence: stage.Sequence = None,
     onnx_opset: Optional[int] = None,
     device: Optional[str] = None,
-) -> build.Config:
+) -> fs.State:
     """
     Process the user's configuration arguments to build_model():
     1. Raise exceptions for illegal arguments
@@ -31,10 +31,8 @@ def lock_config(
     """
 
     # The default model name is the name of the python file that calls build_model()
-    auto_name = False
     if build_name is None:
         build_name = os.path.basename(sys.argv[0])
-        auto_name = True
 
     if sequence is None:
         # The value ["default"] indicates that build_model() will be assigning some
@@ -68,15 +66,14 @@ def lock_config(
         device_to_use = device
 
     # Store the args that should be immutable
-    config = build.Config(
+    state = fs.State(
         build_name=build_name,
-        auto_name=auto_name,
         sequence=stage_names,
         onnx_opset=opset_to_use,
         device=device_to_use,
     )
 
-    return config
+    return state
 
 
 def decode_version_number(version: str) -> Dict[str, int]:
@@ -85,9 +82,9 @@ def decode_version_number(version: str) -> Dict[str, int]:
 
 
 def validate_cached_model(
-    config: build.Config,
+    new_state: fs.State,
+    cached_state: fs.State,
     model_type: build.ModelType,
-    state: build.State,
     model: build.UnionValidModelInstanceTypes = None,
     inputs: Optional[Dict[str, Any]] = None,
 ) -> List[str]:
@@ -103,7 +100,7 @@ def validate_cached_model(
     result = []
 
     current_version_decoded = decode_version_number(turnkey_version)
-    state_version_decoded = decode_version_number(state.turnkey_version)
+    state_version_decoded = decode_version_number(cached_state.turnkey_version)
 
     out_of_date: Union[str, bool] = False
     if current_version_decoded["major"] > state_version_decoded["major"]:
@@ -113,8 +110,8 @@ def validate_cached_model(
 
     if out_of_date:
         msg = (
-            f"Your build {state.config.build_name} was previously built against "
-            f"turnkey version {state.turnkey_version}, "
+            f"Your build {cached_state.build_name} was previously built against "
+            f"turnkey version {cached_state.turnkey_version}, "
             f"however you are now using turnkey version {turnkey_version}. The previous build is "
             f"incompatible with this version of turnkey, as indicated by the {out_of_date} "
             "version number changing. See **docs/versioning.md** for details."
@@ -122,7 +119,7 @@ def validate_cached_model(
         result.append(msg)
 
     if model is not None:
-        model_changed = state.model_hash != build.hash_model(model, model_type)
+        model_changed = cached_state.model_hash != build.hash_model(model, model_type)
     else:
         model_changed = False
 
@@ -132,9 +129,9 @@ def validate_cached_model(
             input_dtypes_changed,
         ) = tensor_helpers.check_shapes_and_dtypes(
             inputs,
-            state.expected_input_shapes,
-            state.expected_input_dtypes,
-            expect_downcast=state.downcast_applied,
+            cached_state.expected_input_shapes,
+            cached_state.expected_input_dtypes,
+            expect_downcast=cached_state.downcast_applied,
             raise_error=False,
         )
     else:
@@ -142,9 +139,15 @@ def validate_cached_model(
         input_dtypes_changed = False
 
     changed_args = []
-    for key in vars(state.config):
-        if vars(config)[key] != vars(state.config)[key]:
-            changed_args.append((key, vars(config)[key], vars(state.config)[key]))
+    for key in [
+        fs.Keys.BUILD_NAME,
+        fs.Keys.ONNX_OPSET,
+        fs.Keys.DEVICE,
+        fs.Keys.SEQUENCE,
+    ]:
+        # TODO: replace `vars(new_state)[key]` with `new_state.key`
+        if vars(new_state)[key] != vars(cached_state)[key]:
+            changed_args.append((key, vars(new_state)[key], vars(cached_state)[key]))
 
     # Show an error if the model changed
     build_conditions_changed = (
@@ -155,7 +158,7 @@ def validate_cached_model(
     )
     if build_conditions_changed:
         # Show an error if build_name is not specified for different models on the same script
-        if state.uid == build.unique_id():
+        if cached_state.uid == build.unique_id():
             msg = (
                 "You are building multiple different models in the same script "
                 "without specifying a unique build_model(..., build_name=) for each build."
@@ -163,16 +166,14 @@ def validate_cached_model(
             result.append(msg)
 
         if model_changed:
-            msg = (
-                f'Model "{config.build_name}" changed since the last time it was built.'
-            )
+            msg = f'Model "{new_state.build_name}" changed since the last time it was built.'
             result.append(msg)
 
         if input_shapes_changed:
             input_shapes, _ = build.get_shapes_and_dtypes(inputs)
             msg = (
-                f'Input shape of model "{config.build_name}" changed from '
-                f"{state.expected_input_shapes} to {input_shapes} "
+                f'Input shape of model "{new_state.build_name}" changed from '
+                f"{cached_state.expected_input_shapes} to {input_shapes} "
                 f"since the last time it was built."
             )
             result.append(msg)
@@ -180,8 +181,8 @@ def validate_cached_model(
         if input_dtypes_changed:
             _, input_dtypes = build.get_shapes_and_dtypes(inputs)
             msg = (
-                f'Input data type of model "{config.build_name}" changed from '
-                f"{state.expected_input_dtypes} to {input_dtypes} "
+                f'Input data type of model "{new_state.build_name}" changed from '
+                f"{cached_state.expected_input_dtypes} to {input_dtypes} "
                 f"since the last time it was built."
             )
             result.append(msg)
@@ -190,16 +191,16 @@ def validate_cached_model(
             for key_name, current_arg, previous_arg in changed_args:
                 msg = (
                     f'build_model() argument "{key_name}" for build '
-                    f"{config.build_name} changed from "
+                    f"{new_state.build_name} changed from "
                     f"{previous_arg} to {current_arg} since the last build."
                 )
                 result.append(msg)
     else:
         if (
-            state.build_status == build.FunctionStatus.ERROR
-            or state.build_status == build.FunctionStatus.INCOMPLETE
-            or state.build_status == build.FunctionStatus.KILLED
-        ) and turnkey_version == state.turnkey_version:
+            cached_state.build_status == build.FunctionStatus.ERROR
+            or cached_state.build_status == build.FunctionStatus.INCOMPLETE
+            or cached_state.build_status == build.FunctionStatus.KILLED
+        ) and turnkey_version == cached_state.turnkey_version:
             msg = (
                 "build_model() has detected that you already attempted building "
                 "this model with the exact same model, inputs, options, and version of "
@@ -212,33 +213,30 @@ def validate_cached_model(
 
 def _begin_fresh_build(
     state_args: Dict,
-    state_type: Type = build.State,
-) -> build.State:
+) -> fs.State:
     # Wipe everything in this model's build directory, except for the stats file,
     # start with a fresh State.
-    stats = filesystem.Stats(state_args["cache_dir"], state_args["config"].build_name)
+    stats = fs.Stats(state_args["cache_dir"], state_args["config"].build_name)
 
     build_dir = build.output_dir(
         state_args["cache_dir"], state_args["config"].build_name
     )
 
-    filesystem.rmdir(
+    fs.rmdir(
         build_dir,
         excludes=[
             stats.file,
-            os.path.join(build_dir, filesystem.BUILD_MARKER),
+            os.path.join(build_dir, fs.BUILD_MARKER),
         ],
     )
-    state = state_type(**state_args)
+    state = fs.State(**state_args)
     state.save()
 
     return state
 
 
-def _rebuild_if_needed(
-    problem_report: str, state_args: Dict, state_type: Type = build.State
-):
-    build_name = state_args["config"].build_name
+def _rebuild_if_needed(problem_report: str, state_args: Dict):
+    build_name = state_args[fs.Keys.BUILD_NAME]
     msg = (
         f"build_model() discovered a cached build of {build_name}, but decided to "
         "rebuild for the following reasons: \n\n"
@@ -248,11 +246,11 @@ def _rebuild_if_needed(
     )
     printing.log_warning(msg)
 
-    return _begin_fresh_build(state_args, state_type=state_type)
+    return _begin_fresh_build(state_args)
 
 
 def load_or_make_state(
-    config: build.Config,
+    new_state: fs.State,
     evaluation_id: str,
     cache_dir: str,
     rebuild: str,
@@ -260,28 +258,16 @@ def load_or_make_state(
     monitor: bool,
     model: build.UnionValidModelInstanceTypes = None,
     inputs: Optional[Dict[str, Any]] = None,
-    state_type: Type = build.State,
-    cache_validation_func: Callable = validate_cached_model,
-    extra_state_args: Optional[Dict] = None,
-) -> build.State:
+) -> fs.State:
     """
     Decide whether we can load the model from the model cache
     (return a valid State instance) or whether we need to rebuild it (return
     a new State instance).
-    """
 
-    # Put all the args for making a new State instance into a dict
-    # to help the following code be cleaner
-    state_args = {
-        "model": model,
-        "inputs": inputs,
-        "monitor": monitor,
-        "rebuild": rebuild,
-        "evaluation_id": evaluation_id,
-        "cache_dir": cache_dir,
-        "config": config,
-        "model_type": model_type,
-    }
+    We make this decision on the basis of whether the cached state used
+    the same model, inputs, and build arguments as the new state generated
+    by this call to the tool.
+    """
 
     # Ensure that `rebuild` has a valid value
     if rebuild not in build.REBUILD_OPTIONS:
@@ -290,103 +276,80 @@ def load_or_make_state(
             f"however the only allowed values of `rebuild` are {build.REBUILD_OPTIONS}"
         )
 
-    # Allow customizations of turnkey to supply additional args
-    if extra_state_args is not None:
-        state_args.update(extra_state_args)
+    # Put all the args for making a new State instance into a dict
+    # to help the following code be cleaner
+    state_args = {
+        fs.Keys.MODEL: model,
+        fs.Keys.INPUTS: inputs,
+        fs.Keys.MONITOR: monitor,
+        fs.Keys.EVALUATION_ID: evaluation_id,
+        fs.Keys.CACHE_DIR: cache_dir,
+        fs.Keys.MODEL_TYPE: model_type,
+        **new_state._members,
+    }
 
     if rebuild == "always":
-        return _begin_fresh_build(state_args, state_type)
+        return _begin_fresh_build(state_args)
     else:
         # Try to load state and check if model successfully built before
-        if os.path.isfile(build.state_file(cache_dir, config.build_name)):
+        if os.path.isfile(build.state_file(cache_dir, new_state.build_name)):
             try:
-                state = build.load_state(
+                cached_state = fs.load_state(
                     cache_dir,
-                    config.build_name,
-                    state_type=state_type,
+                    new_state.build_name,
                 )
 
             except exp.StateError as e:
                 problem = (
                     "- build_model() failed to load "
-                    f"{build.state_file(cache_dir, config.build_name)}"
+                    f"{build.state_file(cache_dir, new_state.build_name)}"
                 )
 
                 if rebuild == "if_needed":
-                    return _rebuild_if_needed(problem, state_args, state_type)
+                    return _rebuild_if_needed(problem, state_args)
                 else:
                     # Give the rebuild="never" users a chance to address the problem
                     raise exp.CacheError(e)
 
-            if (
-                model_type == build.ModelType.UNKNOWN
-                and state.build_status == build.FunctionStatus.SUCCESSFUL
-            ):
-                msg = (
-                    "Model caching is disabled for successful builds against custom Sequences. "
-                    "Your model will rebuild whenever you call build_model() on it."
-                )
-                printing.log_warning(msg)
+            cache_problems = validate_cached_model(
+                new_state=new_state,
+                cached_state=cached_state,
+                model_type=model_type,
+                model=model,
+                inputs=inputs,
+            )
 
-                return _begin_fresh_build(state_args, state_type)
-            elif (
-                model_type == build.ModelType.UNKNOWN
-                and state.build_status == build.FunctionStatus.INCOMPLETE
-            ):
-                msg = (
-                    f"Model {config.build_name} was partially built in a previous call to "
-                    "build_model(). This call to build_model() found that partial build and "
-                    "is loading it from the build cache."
-                )
+            if len(cache_problems) > 0:
+                cache_problems = [f"- {msg}" for msg in cache_problems]
+                problem_report = "\n".join(cache_problems)
 
-                printing.log_info(msg)
-            else:
-                cache_problems = cache_validation_func(
-                    config=config,
-                    model_type=model_type,
-                    state=state,
-                    model=model,
-                    inputs=inputs,
-                )
+                if rebuild == "if_needed":
+                    return _rebuild_if_needed(problem_report, state_args)
+                if rebuild == "never":
+                    msg = (
+                        "build_model() discovered a cached build of "
+                        f"{new_state.build_name}, and found that it "
+                        "is likely invalid for the following reasons: \n\n"
+                        f"{problem_report} \n\n"
+                        "build_model() will raise a SkipBuild exception because you have "
+                        "set rebuild=never. "
+                    )
+                    printing.log_warning(msg)
 
-                if len(cache_problems) > 0:
-                    cache_problems = [f"- {msg}" for msg in cache_problems]
-                    problem_report = "\n".join(cache_problems)
-
-                    if rebuild == "if_needed":
-                        return _rebuild_if_needed(
-                            problem_report, state_args, state_type
-                        )
-                    if rebuild == "never":
-                        msg = (
-                            "build_model() discovered a cached build of "
-                            f"{config.build_name}, and found that it "
-                            "is likely invalid for the following reasons: \n\n"
-                            f"{problem_report} \n\n"
-                            "build_model() will raise a SkipBuild exception because you have "
-                            "set rebuild=never. "
-                        )
-                        printing.log_warning(msg)
-
-                        raise exp.SkipBuild(
-                            "Skipping this build, by raising an exception, because it previously "
-                            "failed and the `rebuild` argument is set to `never`."
-                        )
+                    raise exp.SkipBuild(
+                        "Skipping this build, by raising an exception, because it previously "
+                        "failed and the `rebuild` argument is set to `never`."
+                    )
 
             # Ensure the model and inputs are part of the state
-            # This is useful  when loading models that still need to be built
-            state.save_when_setting_attribute = False
-            if state.model is None:
-                state.model = model
-            if state.inputs is None:
-                state.inputs = inputs
-            state.save_when_setting_attribute = True
+            new_state.model = model
+            new_state.inputs = inputs
 
-            return state
+            return new_state
 
         else:
             # No state file found, so we have to build
-            return _begin_fresh_build(state_args, state_type)
+            return _begin_fresh_build(state_args)
 
 
 export_map = {

--- a/src/turnkeyml/build/ignition.py
+++ b/src/turnkeyml/build/ignition.py
@@ -40,8 +40,27 @@ def validate_cached_model(
     if vars(cached_state).get(fs.Keys.BUILD_STATUS) != build.FunctionStatus.SUCCESSFUL:
         return ["Your cached build was not successful."]
 
+    # All of the state properties analyzed by this function
+    # should be listed here.
+    cache_analysis_properties = [
+        fs.Keys.BUILD_NAME,
+        fs.Keys.ONNX_OPSET,
+        fs.Keys.DEVICE,
+        fs.Keys.SEQUENCE,
+        fs.Keys.BUILD_STATUS,
+        fs.Keys.TURNKEY_VERSION,
+        fs.Keys.MODEL_HASH,
+        fs.Keys.EXPECTED_INPUT_DTYPES,
+        fs.Keys.EXPECTED_INPUT_SHAPES,
+        fs.Keys.DOWNCAST_APPLIED,
+        fs.Keys.UID,
+        fs.Keys.EVALUATION_ID,
+        fs.Keys.MODEL_TYPE,
+    ]
+
     # Make sure the cached state contains all information needed to assess a cache hit
-    for key in fs.cache_analysis_properties:
+    # so that we don't hit an attribute error down the function
+    for key in cache_analysis_properties:
         if key not in vars(cached_state).keys():
             return [
                 (

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -293,7 +293,7 @@ class Sequence(Stage):
         # At the beginning of a sequence no stage has started
         for stage in self.stages:
             stats.save_model_eval_stat(
-                stage.status_key, build.FunctionStatus.NOT_STARTED.value
+                stage.status_key, build.FunctionStatus.NOT_STARTED
             )
             stats.save_model_eval_stat(stage.duration_key, "-")
 
@@ -305,7 +305,7 @@ class Sequence(Stage):
 
                 # Set status as incomplete, since stage just started
                 stats.save_model_eval_stat(
-                    stage.status_key, build.FunctionStatus.INCOMPLETE.value
+                    stage.status_key, build.FunctionStatus.INCOMPLETE
                 )
 
                 # Collect telemetry about the stage
@@ -319,9 +319,7 @@ class Sequence(Stage):
             except Exception as e:  # pylint: disable=broad-except
 
                 # Update Stage Status
-                stats.save_model_eval_stat(
-                    stage.status_key, build.FunctionStatus.ERROR.value
-                )
+                stats.save_model_eval_stat(stage.status_key, build.FunctionStatus.ERROR)
 
                 # Save the log file for the failed stage to stats for easy reference
                 stats.save_eval_error_log(stage.logfile_path)
@@ -343,7 +341,7 @@ class Sequence(Stage):
             else:
                 # Update Stage Status
                 stats.save_model_eval_stat(
-                    stage.status_key, build.FunctionStatus.SUCCESSFUL.value
+                    stage.status_key, build.FunctionStatus.SUCCESSFUL
                 )
 
             finally:

--- a/src/turnkeyml/build_api.py
+++ b/src/turnkeyml/build_api.py
@@ -55,20 +55,11 @@ def build_model(
             https://github.com/onnx/turnkeyml/blob/main/docs/tools_user_guide.md
     """
 
-    # Allow monitor to be globally disabled by an environment variable
-    if monitor is None:
-        if os.environ.get("TURNKEY_BUILD_MONITOR") == "False":
-            monitor_setting = False
-        else:
-            monitor_setting = True
-    else:
-        monitor_setting = monitor
-
     # Validate and apply defaults to the initial user arguments that
     # configure the build
     state = ignition.initialize_state(
         model=model,
-        monitor=monitor_setting,
+        monitor=monitor,
         evaluation_id=evaluation_id,
         cache_dir=cache_dir,
         build_name=build_name,

--- a/src/turnkeyml/build_api.py
+++ b/src/turnkeyml/build_api.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional, List, Dict, Any
 import turnkeyml.build.ignition as ignition
 import turnkeyml.build.stage as stage
@@ -55,19 +54,6 @@ def build_model(
             https://github.com/onnx/turnkeyml/blob/main/docs/tools_user_guide.md
     """
 
-    # Validate and apply defaults to the initial user arguments that
-    # configure the build
-    state = ignition.initialize_state(
-        model=model,
-        monitor=monitor,
-        evaluation_id=evaluation_id,
-        cache_dir=cache_dir,
-        build_name=build_name,
-        sequence=sequence,
-        onnx_opset=onnx_opset,
-        device=device,
-    )
-
     # Analyze the user's model argument and lock in the model, inputs,
     # and sequence that will be used by the rest of the toolchain
     (
@@ -78,6 +64,21 @@ def build_model(
         model,
         inputs,
         sequence,
+    )
+
+    # Validate and apply defaults to the initial user arguments that
+    # configure the build
+    state = fs.State(
+        model=model,
+        model_type=model_type,
+        inputs=inputs_locked,
+        monitor=monitor,
+        evaluation_id=evaluation_id,
+        cache_dir=cache_dir,
+        build_name=build_name,
+        sequence=sequence,
+        onnx_opset=onnx_opset,
+        device=device,
     )
 
     # Get the state of the model from the cache if a valid build is available

--- a/src/turnkeyml/build_api.py
+++ b/src/turnkeyml/build_api.py
@@ -11,7 +11,7 @@ def build_model(
     model: build.UnionValidModelInstanceTypes = None,
     inputs: Optional[Dict[str, Any]] = None,
     build_name: Optional[str] = None,
-    evaluation_id: Optional[str] = "build",
+    evaluation_id: str = "build",
     cache_dir: str = fs.DEFAULT_CACHE_DIR,
     monitor: Optional[bool] = None,
     rebuild: Optional[str] = None,
@@ -64,13 +64,13 @@ def build_model(
     else:
         monitor_setting = monitor
 
-    # Support "~" in the cache_dir argument
-    parsed_cache_dir = os.path.expanduser(cache_dir)
-
-    # Validate and lock in the initial state (user arguments that
-    # configure the build) that will be used by the rest of the toolchain
+    # Validate and apply defaults to the initial user arguments that
+    # configure the build
     state = ignition.initialize_state(
         model=model,
+        monitor=monitor_setting,
+        evaluation_id=evaluation_id,
+        cache_dir=cache_dir,
         build_name=build_name,
         sequence=sequence,
         onnx_opset=onnx_opset,
@@ -80,7 +80,6 @@ def build_model(
     # Analyze the user's model argument and lock in the model, inputs,
     # and sequence that will be used by the rest of the toolchain
     (
-        model_locked,
         inputs_locked,
         sequence_locked,
         model_type,
@@ -93,12 +92,8 @@ def build_model(
     # Get the state of the model from the cache if a valid build is available
     state = ignition.load_or_make_state(
         new_state=state,
-        evaluation_id=evaluation_id,
-        cache_dir=parsed_cache_dir,
         rebuild=rebuild or build.DEFAULT_REBUILD_POLICY,
         model_type=model_type,
-        monitor=monitor_setting,
-        model=model_locked,
         inputs=inputs_locked,
     )
 

--- a/src/turnkeyml/build_api.py
+++ b/src/turnkeyml/build_api.py
@@ -82,7 +82,7 @@ def build_model(
     )
 
     # Get the state of the model from the cache if a valid build is available
-    state = ignition.load_or_make_state(
+    state = ignition.load_from_cache(
         new_state=state,
         rebuild=rebuild or build.DEFAULT_REBUILD_POLICY,
         model_type=model_type,

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -5,7 +5,7 @@ import copy
 from difflib import get_close_matches
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exceptions
-import turnkeyml.common.filesystem as filesystem
+import turnkeyml.common.filesystem as fs
 import turnkeyml.cli.report as report
 import turnkeyml.cli.parser_helpers as parser_helpers
 from turnkeyml.files_api import benchmark_files
@@ -34,11 +34,9 @@ def print_version(_):
 
 def print_stats(args):
     state_path = build.state_file(args.cache_dir, args.build_name)
-    filesystem.print_yaml_file(state_path, "build state")
+    fs.print_yaml_file(state_path, "build state")
 
-    filesystem.print_yaml_file(
-        filesystem.Stats(args.cache_dir, args.build_name).file, "stats"
-    )
+    fs.print_yaml_file(fs.Stats(args.cache_dir, args.build_name).file, "stats")
 
 
 def benchmark_command(args):
@@ -192,9 +190,9 @@ def main():
         "--cache-dir",
         dest="cache_dir",
         help="Build cache directory where the resulting build directories will "
-        f"be stored (defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        f"be stored (defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     both_build_benchmark_group.add_argument(
@@ -330,9 +328,9 @@ def main():
         dest="cache_dirs",
         help=(
             "One or more build cache directories to generate the report "
-            f"(defaults to {filesystem.DEFAULT_CACHE_DIR})"
+            f"(defaults to {fs.DEFAULT_CACHE_DIR})"
         ),
-        default=[filesystem.DEFAULT_CACHE_DIR],
+        default=[fs.DEFAULT_CACHE_DIR],
         nargs="*",
     )
 
@@ -352,16 +350,16 @@ def main():
     list_parser = cache_subparsers.add_parser(
         "list", help="List all builds in a target cache"
     )
-    list_parser.set_defaults(func=filesystem.print_available_builds)
+    list_parser.set_defaults(func=fs.print_available_builds)
 
     list_parser.add_argument(
         "-d",
         "--cache-dir",
         dest="cache_dir",
         help="The builds in this build cache directory will printed to the terminal "
-        f" (defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        f" (defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     #######################################
@@ -378,9 +376,9 @@ def main():
         "--cache-dir",
         dest="cache_dir",
         help="The stats of a build in this build cache directory will printed to the terminal "
-        f" (defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        f" (defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     stats_parser.add_argument(
@@ -395,15 +393,15 @@ def main():
     delete_parser = cache_subparsers.add_parser(
         "delete", help="Delete one or more builds in a build cache"
     )
-    delete_parser.set_defaults(func=filesystem.delete_builds)
+    delete_parser.set_defaults(func=fs.delete_builds)
 
     delete_parser.add_argument(
         "-d",
         "--cache-dir",
         dest="cache_dir",
-        help="Search path for builds " f"(defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        help="Search path for builds " f"(defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     delete_group = delete_parser.add_mutually_exclusive_group(required=True)
@@ -429,15 +427,15 @@ def main():
         "clean",
         help="Remove the build artifacts from one or more builds in a build cache",
     )
-    clean_parser.set_defaults(func=filesystem.clean_builds)
+    clean_parser.set_defaults(func=fs.clean_builds)
 
     clean_parser.add_argument(
         "-d",
         "--cache-dir",
         dest="cache_dir",
-        help="Search path for builds " f"(defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        help="Search path for builds " f"(defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     clean_group = clean_parser.add_mutually_exclusive_group(required=True)
@@ -463,7 +461,7 @@ def main():
         "location",
         help="Print the location of the default build cache directory",
     )
-    cache_location_parser.set_defaults(func=filesystem.print_cache_dir)
+    cache_location_parser.set_defaults(func=fs.print_cache_dir)
 
     #######################################
     # Parser for the "cache benchmark" command
@@ -479,9 +477,9 @@ def main():
         "-d",
         "--cache-dir",
         dest="cache_dir",
-        help="Search path for builds " f"(defaults to {filesystem.DEFAULT_CACHE_DIR})",
+        help="Search path for builds " f"(defaults to {fs.DEFAULT_CACHE_DIR})",
         required=False,
-        default=filesystem.DEFAULT_CACHE_DIR,
+        default=fs.DEFAULT_CACHE_DIR,
     )
 
     cache_benchmark_group = cache_benchmark_parser.add_mutually_exclusive_group(
@@ -572,7 +570,7 @@ def main():
         "location",
         help="Print the location of the models directory",
     )
-    models_location_parser.set_defaults(func=filesystem.print_models_dir)
+    models_location_parser.set_defaults(func=fs.print_models_dir)
 
     models_location_parser.add_argument(
         "--quiet",

--- a/src/turnkeyml/cli/report.py
+++ b/src/turnkeyml/cli/report.py
@@ -88,8 +88,8 @@ def summary_spreadsheets(args) -> None:
                                     or fs.Keys.BENCHMARK_STATUS
                                 )
                                 or fs.Keys.STAGE_STATUS in key
-                            ) and value == bd.FunctionStatus.INCOMPLETE.value:
-                                value = bd.FunctionStatus.KILLED.value
+                            ) and value == bd.FunctionStatus.INCOMPLETE:
+                                value = bd.FunctionStatus.KILLED
 
                             # Add stats ensuring that those are all in lower case
                             evaluation_stats[key.lower()] = value

--- a/src/turnkeyml/cli/report.py
+++ b/src/turnkeyml/cli/report.py
@@ -7,7 +7,7 @@ import yaml
 import pandas as pd
 import turnkeyml.common.printing as printing
 import turnkeyml.common.filesystem as fs
-import turnkeyml.common.build as bd
+import turnkeyml.common.build as build
 
 
 def get_report_name(prefix: str = "") -> str:
@@ -88,8 +88,8 @@ def summary_spreadsheets(args) -> None:
                                     or fs.Keys.BENCHMARK_STATUS
                                 )
                                 or fs.Keys.STAGE_STATUS in key
-                            ) and value == bd.FunctionStatus.INCOMPLETE:
-                                value = bd.FunctionStatus.KILLED
+                            ) and value == build.FunctionStatus.INCOMPLETE:
+                                value = build.FunctionStatus.KILLED
 
                             # Add stats ensuring that those are all in lower case
                             evaluation_stats[key.lower()] = value
@@ -126,8 +126,8 @@ def summary_spreadsheets(args) -> None:
     with open(report_path, "w", newline="", encoding="utf8") as spreadsheet:
         writer = csv.writer(spreadsheet)
         writer.writerow(column_headers)
-        for build in report:
-            writer.writerow([build[col] for col in column_headers])
+        for entry in report:
+            writer.writerow([entry[col] for col in column_headers])
 
     # Print message with the output file path
     printing.log("Summary spreadsheet saved at ")

--- a/src/turnkeyml/cli/spawn.py
+++ b/src/turnkeyml/cli/spawn.py
@@ -376,9 +376,9 @@ def run_turnkey(
                         for key in stats.evaluation_stats.keys():
                             if (
                                 stats.evaluation_stats[key]
-                                == build.FunctionStatus.INCOMPLETE.value
+                                == build.FunctionStatus.INCOMPLETE
                             ):
-                                stats.save_model_eval_stat(key, evaluation_status.value)
+                                stats.save_model_eval_stat(key, evaluation_status)
 
                         # Save the exception into the error log stat
                         stats.save_model_eval_stat(filesystem.Keys.ERROR_LOG, str(e))

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -103,7 +103,7 @@ def hash_model(model, model_type: ModelType, hash_params: bool = True):
         raise ValueError(msg)
 
 
-class FunctionStatus(enum.Enum):
+class FunctionStatus:
     """
     Status values that are assigned to stages, builds, benchmarks, and other
     functionality to help the user understand whether that function completed

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -4,7 +4,6 @@ import sys
 import traceback
 import platform
 import subprocess
-import enum
 from typing import Dict, Union
 import hashlib
 import pkg_resources
@@ -33,7 +32,7 @@ DEFAULT_REBUILD_POLICY = "if_needed"
 REBUILD_OPTIONS = ["if_needed", "always", "never"]
 
 
-class ModelType(enum.Enum):
+class ModelType:
     PYTORCH = "pytorch"
     PYTORCH_COMPILED = "pytorch_compiled"
     ONNX_FILE = "onnx_file"

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -1,14 +1,11 @@
 import os
 import logging
 import sys
-import pathlib
-import copy
 import traceback
 import platform
 import subprocess
 import enum
-from typing import Optional, Any, List, Dict, Union, Type
-import dataclasses
+from typing import Dict, Union
 import hashlib
 import pkg_resources
 import psutil
@@ -16,7 +13,6 @@ import yaml
 import torch
 import numpy as np
 import turnkeyml.common.exceptions as exp
-from turnkeyml.version import __version__ as turnkey_version
 
 
 UnionValidModelInstanceTypes = Union[
@@ -48,7 +44,7 @@ class ModelType(enum.Enum):
 DEFAULT_DEVICE = "default"
 
 
-def load_yaml(file_path):
+def load_yaml(file_path) -> Dict:
     with open(file_path, "r", encoding="utf8") as stream:
         try:
             return yaml.load(stream, Loader=yaml.FullLoader)
@@ -203,185 +199,6 @@ def get_shapes_and_dtypes(inputs: dict):
             )
 
     return shapes, dtypes
-
-
-@dataclasses.dataclass(frozen=True)
-class Config:
-    """
-    User-provided build configuration. Instances of Config should not be modified
-    once they have been instantiated (frozen=True enforces this).
-
-    Note: modifying this struct can create a breaking change that
-    requires users to rebuild their models. Increment the minor
-    version number of the turnkey package if you do make a build-
-    breaking change.
-    """
-
-    build_name: str
-    auto_name: bool
-    sequence: List[str]
-    onnx_opset: int
-    device: Optional[str]
-
-
-@dataclasses.dataclass
-class State:
-    # User-provided args that influence the generated model
-    config: Config
-
-    # User-provided args that do not influence the generated model
-    monitor: bool = False
-    rebuild: str = ""
-    cache_dir: str = ""
-    evaluation_id: str = ""
-
-    # User-provided args that will not be saved as part of state.yaml
-    model: UnionValidModelInstanceTypes = None
-    inputs: Optional[Dict[str, Any]] = None
-
-    # Member variable that helps the code know if State has called
-    # __post_init__ yet
-    save_when_setting_attribute: bool = False
-
-    # All of the following are critical aspects of the build,
-    # including properties of the tool and choices made
-    # while building the model, which determine the outcome of the build.
-    # NOTE: adding or changing a member name in this struct can create
-    # a breaking change that requires users to rebuild their models.
-    # Increment the minor version number of the turnkey package if you
-    # do make a build-breaking change.
-
-    turnkey_version: str = turnkey_version
-    model_type: ModelType = ModelType.UNKNOWN
-    uid: Optional[int] = None
-    model_hash: Optional[int] = None
-    build_status: FunctionStatus = FunctionStatus.NOT_STARTED
-    expected_input_shapes: Optional[Dict[str, list]] = None
-    expected_input_dtypes: Optional[Dict[str, list]] = None
-    expected_output_names: Optional[List] = None
-
-    # Whether or not inputs must be downcasted during inference
-    downcast_applied: bool = False
-
-    # The results of the most recent stage that was executed
-    current_build_stage: str = None
-    intermediate_results: Any = None
-
-    # Results of a successful build
-    results: Any = None
-
-    def __post_init__(self):
-        if self.uid is None:
-            self.uid = unique_id()
-        if self.inputs is not None:
-            (
-                self.expected_input_shapes,
-                self.expected_input_dtypes,
-            ) = get_shapes_and_dtypes(self.inputs)
-        if self.model is not None and self.model_type != ModelType.UNKNOWN:
-            self.model_hash = hash_model(self.model, self.model_type)
-
-        self.save_when_setting_attribute = True
-
-    def __setattr__(self, name, val):
-        super().__setattr__(name, val)
-
-        # Always automatically save the state.yaml whenever State is modified
-        # But don't bother saving until after __post_init__ is done (indicated
-        # by the save_when_setting_attribute flag)
-        # Note: This only works when elements of the state are set directly.
-        if self.save_when_setting_attribute and name != "save_when_setting_attribute":
-            self.save()
-
-    @property
-    def original_inputs_file(self):
-        return os.path.join(
-            output_dir(self.cache_dir, self.config.build_name), "inputs.npy"
-        )
-
-    def prepare_file_system(self):
-        # Create output folder if it doesn't exist
-        os.makedirs(output_dir(self.cache_dir, self.config.build_name), exist_ok=True)
-
-    def prepare_state_dict(self) -> Dict:
-        state_dict = {
-            key: value
-            for key, value in vars(self).items()
-            if not key == "inputs"
-            and not key == "model"
-            and not key == "save_when_setting_attribute"
-        }
-
-        # Special case for saving objects
-        state_dict["config"] = copy.deepcopy(vars(self.config))
-
-        state_dict["model_type"] = self.model_type.value
-        state_dict["build_status"] = self.build_status.value
-
-        return state_dict
-
-    def save_yaml(self, state_dict: Dict):
-        with open(
-            state_file(self.cache_dir, self.config.build_name), "w", encoding="utf8"
-        ) as outfile:
-            yaml.dump(state_dict, outfile)
-
-    def save(self):
-        self.prepare_file_system()
-
-        state_dict = self.prepare_state_dict()
-
-        self.save_yaml(state_dict)
-
-
-def load_state(
-    cache_dir=None,
-    build_name=None,
-    state_path=None,
-    state_type: Type = State,
-) -> State:
-    if state_path is not None:
-        file_path = state_path
-    elif build_name is not None and cache_dir is not None:
-        file_path = state_file(cache_dir, build_name)
-    else:
-        raise ValueError(
-            "This function requires either build_name and cache_dir to be set, "
-            "or state_path to be set, not both or neither"
-        )
-
-    state_dict = load_yaml(file_path)
-
-    # Get the type of Config and Info in case they have been overloaded
-    field_types = {field.name: field.type for field in dataclasses.fields(state_type)}
-    config_type = field_types["config"]
-
-    try:
-        # Special case for loading enums
-        state_dict["model_type"] = ModelType(state_dict["model_type"])
-        state_dict["build_status"] = FunctionStatus(state_dict["build_status"])
-        state_dict["config"] = config_type(**state_dict["config"])
-
-        state = state_type(**state_dict)
-
-    except (KeyError, TypeError) as e:
-        if state_path is not None:
-            path_suggestion = pathlib.Path(state_path).parent
-        else:
-            path_suggestion = output_dir(cache_dir, build_name)
-        msg = f"""
-        The cached build of this model was built with an
-        incompatible older version of the tool.
-
-        Suggested solution: delete the build with
-        rm -rf {path_suggestion}
-
-        The underlying code raised this exception:
-        {e}
-        """
-        raise exp.StateError(msg)
-
-    return state
 
 
 class Logger:

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -1,14 +1,18 @@
 import os
+import sys
 import shutil
 import glob
 import pathlib
 from typing import Dict, List, Optional, Any
 import importlib.util
 import yaml
+import onnx
 import turnkeyml.common.printing as printing
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
 from turnkeyml.common import labels
+from turnkeyml.version import __version__ as turnkey_version
+import turnkeyml.build.onnx_helpers as onnx_helpers
 
 # Allow an environment variable to override the default
 # location for the build cache
@@ -617,15 +621,135 @@ def sanitize_for_yaml(input_dict: Dict) -> Dict:
 
 
 class State:
-    def __init__(self, **kwargs):
+    """
+    The State class is meant to carry build state, starting with the user's
+    initial arguments, through each build Stage in the Sequence, and finally
+    to the disk, where it is used to assess cache hits.
 
+    State is initialized with the key members that are shared by every build,
+    and reasonable default values are assigned as appropriate.
+
+    Stage developers can also add any members they wish. To get or set an
+    attribute, reference it as an attribute:
+        1. get: `my_variable = state.attribute_name`
+        1. set: `state.attribute_name = my_variable`
+
+    Build State can be saved and loaded from disk in the form of a state.yaml file
+    via State.save() and load_state(), respectively. Note that while State can
+    contain members of any type, only YAML-safe members (str, int, bool, float,
+    list, dict, tuple) will be saved and loaded.
+    """
+
+    def __init__(
+        self,
+        evaluation_id: str,
+        cache_dir: str,
+        model: Optional[build.UnionValidModelInstanceTypes] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        model_type: Optional[build.ModelType] = None,
+        monitor: Optional[bool] = None,
+        build_name: Optional[str] = None,
+        sequence=None,
+        onnx_opset: Optional[int] = None,
+        device: Optional[str] = None,
+        **kwargs,
+    ):
+
+        # Allow monitor to be globally disabled by an environment variable
+        if monitor is None:
+            if os.environ.get("TURNKEY_BUILD_MONITOR") == "False":
+                monitor_setting = False
+            else:
+                monitor_setting = True
+        else:
+            monitor_setting = monitor
+
+        # The default model name is the name of the python file that calls build_model()
+        if build_name is None:
+            build_name = os.path.basename(sys.argv[0])
+
+        if sequence is None:
+            # The value ["default"] indicates that build_model() will be assigning some
+            # default sequence later in the program
+            stage_names = ["default"]
+        elif isinstance(sequence, list):
+            stage_names = sequence
+        else:
+            stage_names = sequence.get_names()
+
+        # Detect and validate ONNX opset
+        if isinstance(model, str) and model.endswith(".onnx"):
+            onnx_file_opset = onnx_helpers.get_opset(onnx.load(model))
+
+            if onnx_opset is not None and onnx_opset != onnx_file_opset:
+                raise ValueError(
+                    "When using a '.onnx' file as input, the onnx_opset argument must "
+                    "be None or exactly match the ONNX opset of the '.onnx' file. However, the "
+                    f"'.onnx' file has opset {onnx_file_opset}, while onnx_opset was set "
+                    f"to {onnx_opset}"
+                )
+
+            opset_to_use = onnx_file_opset
+        else:
+            if onnx_opset is None:
+                opset_to_use = build.DEFAULT_ONNX_OPSET
+            else:
+                opset_to_use = onnx_opset
+
+        if device is None:
+            device_to_use = build.DEFAULT_DEVICE
+        else:
+            device_to_use = device
+
+        # Support "~" in the cache_dir argument
+        parsed_cache_dir = os.path.expanduser(cache_dir)
+
+        # Save settings as State members
+        self.model = model
+        self.inputs = inputs
+        self.model_type = model_type
+        self.monitor = monitor_setting
+        self.evaluation_id = evaluation_id
+        self.cache_dir = parsed_cache_dir
+        self.build_name = build_name
+        self.sequence = stage_names
+        self.onnx_opset = opset_to_use
+        self.device = device_to_use
+        self.turnkey_version = turnkey_version
+        self.build_status = build.FunctionStatus.NOT_STARTED
+        self.downcast_applied = False
+        self.uid = build.unique_id()
+        self.results = None
+
+        if inputs is not None:
+            self.expected_input_shapes, self.expected_input_dtypes = (
+                build.get_shapes_and_dtypes(inputs)
+            )
+        else:
+            self.expected_input_shapes, self.expected_input_dtypes = None, None
+
+        if self.model is not None and self.model_type != build.ModelType.UNKNOWN:
+            self.model_hash = build.hash_model(self.model, self.model_type)
+
+        # Store any additional kwargs as members
         for key, value in kwargs.items():
             self.__dict__[key] = value
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Stage developers can add a new member to State by simply
+        assigning it as an attribute, ie `state.new_member = value`.
+        """
         return super().__setattr__(name, value)
 
     def save(self):
+        """
+        Save all YAML-friendly members to disk as a state.yaml file.
+
+        Note that `model` and `inputs` will typically not be saved since
+        they are typically in non-YAML-friendly types such as `torch.nn.Module`
+        and `torch.tensor`.
+        """
 
         state_to_save = sanitize_for_yaml(vars(self))
 
@@ -642,6 +766,10 @@ def load_state(
     build_name=None,
     state_path=None,
 ) -> State:
+    """
+    Read a state.yaml file corresponding to a specific build in a specific
+    cache, and use its contents to initialize a State instance.
+    """
 
     if state_path is not None:
         file_path = state_path

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -385,18 +385,8 @@ class Keys:
     SEQUENCE = "sequence"
     # ONNX opset used during model export
     ONNX_OPSET = "onnx_opset"
-    # Whether the build monitor is enabled to provide visibility to the build process
-    MONITOR = "monitor"
-    # Whether to rebuild the model in the event of a cache hit
-    REBUILD = "rebuild"
-    # Cache directory where the build artifacts and logs will be stored
-    CACHE_DIR = "cache_dir"
     # Unique ID for an evaluation (build of a model against a specfic device/runtime/sequence)
     EVALUATION_ID = "evaluation_id"
-    # Model (object or path to file) under evaluation
-    MODEL = "model"
-    # Example inputs to the model
-    INPUTS = "inputs"
     # Version of TurnkeyML used for the build
     TURNKEY_VERSION = "turnkey_version"
     # Indicates what framework (e.g., PyTorch, ONNX) the model was source from
@@ -409,15 +399,8 @@ class Keys:
     EXPECTED_INPUT_SHAPES = "expected_input_shapes"
     # Input data types expected by the model
     EXPECTED_INPUT_DTYPES = "expected_input_dtypes"
-    # Output tensor names produced by the model
-    EXPECTED_OUTPUT_NAMES = "expected_output_names"
     # Whether or not inputs must be downcasted during inference
     DOWNCAST_APPLIED = "downcast_applied"
-    # The results of the most recent stage that was executed
-    CURRENT_BUILD_STAGE = "current_build_stage"
-    INTERMEDIATE_RESULTS = "intermediate_results"
-    # Final result artifact of the build
-    RESULTS = "results"
 
 
 def _clean_logfile(logfile_lines: List[str]) -> List[str]:
@@ -571,24 +554,6 @@ def rebase_cache_dir(input_path: str, build_name: str, new_cache_dir: str):
 
     relative_input_path = input_path.split(build_name, 1)[1][1:]
     return os.path.join(new_cache_dir, build_name, relative_input_path)
-
-
-# All of the state properties analyzed by ignition.validate_cached_model()
-# should be listed here.
-cache_analysis_properties = [
-    Keys.BUILD_NAME,
-    Keys.ONNX_OPSET,
-    Keys.DEVICE,
-    Keys.SEQUENCE,
-    Keys.BUILD_STATUS,
-    Keys.TURNKEY_VERSION,
-    Keys.MODEL_HASH,
-    Keys.EXPECTED_INPUT_DTYPES,
-    Keys.EXPECTED_INPUT_SHAPES,
-    Keys.DOWNCAST_APPLIED,
-    Keys.UID,
-    Keys.EVALUATION_ID,
-]
 
 
 def is_nice_to_write(value):

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -588,22 +588,19 @@ cache_analysis_properties = [
 
 class State:
     def __init__(self, **kwargs):
-        self._members = {}
 
         for key, value in kwargs.items():
-            self._members[key] = value
+            self.__dict__[key] = value
 
-        self.__setattr__ = self.state_set_attr
-        self.__getattribute__ = self.state_get_attr
+        # self.__setattr__ = self.state_set_attr
+        # self.__getattribute__ = self.state_get_attr
 
-    def state_set_attr(self, name: str, value: Any) -> None:
-        self._members[name] = value
+    def __setattr__(self, name: str, value: Any) -> None:
+        # self.__dict__[name] = value
+        return super().__setattr__(name, value)
 
-    def state_get_attr(self, name: str) -> Any:
-        if name.startswith("_"):
-            return self.__dict__[name]
-        else:
-            return self._members[name]
+    # def __getattribute__(self, name: str) -> Any:
+    #     return self.__dict__[name]
 
     def save(self):
         """
@@ -615,16 +612,14 @@ class State:
 
         state_to_save = {}
         # Save results state only if the result is a string (ie, a path to a file)
-        for key, value in self._members.items():
+        for key, value in vars(self).items():
             if key in cache_analysis_properties or (
                 key == Keys.RESULTS and isinstance(key[0], str)
             ):
                 state_to_save[key] = value
 
         with open(
-            build.state_file(
-                self._members[Keys.CACHE_DIR], self._members[Keys.BUILD_NAME]
-            ),
+            build.state_file(self.cache_dir, self.build_name),
             "w",
             encoding="utf8",
         ) as outfile:

--- a/src/turnkeyml/run/basert.py
+++ b/src/turnkeyml/run/basert.py
@@ -10,7 +10,7 @@ import numpy as np
 from turnkeyml.common.performance import MeasuredPerformance, Device
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
-from turnkeyml.common.filesystem import Stats, rebase_cache_dir
+import turnkeyml.common.filesystem as fs
 
 
 def _check_docker_install():
@@ -41,7 +41,7 @@ class BaseRT(ABC):
         self,
         cache_dir: str,
         build_name: str,
-        stats: Stats,
+        stats: fs.Stats,
         device_type: Union[str, Device],
         runtime: str,
         runtimes_supported: List[str],
@@ -177,12 +177,12 @@ class BaseRT(ABC):
             os.remove(self.local_outputs_file)
 
         # Transfer input artifacts
-        state = build.load_state(self.cache_dir, self.build_name)
+        state = fs.load_state(self.cache_dir, self.build_name)
 
         # Just in case the model file was generated on a different machine:
         # strip the state's cache dir, then prepend the current cache dir
-        model_file = rebase_cache_dir(
-            state.results[0], state.config.build_name, self.cache_dir
+        model_file = fs.rebase_cache_dir(
+            state.results[0], state.build_name, self.cache_dir
         )
 
         if not os.path.exists(model_file):

--- a/src/turnkeyml/run/basert.py
+++ b/src/turnkeyml/run/basert.py
@@ -182,7 +182,7 @@ class BaseRT(ABC):
         # Just in case the model file was generated on a different machine:
         # strip the state's cache dir, then prepend the current cache dir
         model_file = fs.rebase_cache_dir(
-            state.results[0], state.build_name, self.cache_dir
+            state.results, state.build_name, self.cache_dir
         )
 
         if not os.path.exists(model_file):

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -122,7 +122,7 @@ def benchmark_build(
     stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
 
     stats.save_model_eval_stat(
-        fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.INCOMPLETE.value
+        fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.INCOMPLETE
     )
 
     benchmark_logfile_path = ""
@@ -157,7 +157,7 @@ def benchmark_build(
         perf.print()
 
         stats.save_model_eval_stat(
-            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL.value
+            fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.SUCCESSFUL
         )
     except Exception as e:
         set_status_on_exception(
@@ -240,8 +240,7 @@ def benchmark_cache(
         eval_stats = stats.evaluation_stats
         if (
             fs.Keys.BENCHMARK_STATUS in eval_stats
-            and eval_stats[fs.Keys.BENCHMARK_STATUS]
-            != build.FunctionStatus.NOT_STARTED.value
+            and eval_stats[fs.Keys.BENCHMARK_STATUS] != build.FunctionStatus.NOT_STARTED
         ):
             if skip_policy == "attempted":
                 printing.log_warning(
@@ -251,7 +250,7 @@ def benchmark_cache(
             elif (
                 skip_policy == "successful"
                 and eval_stats[fs.Keys.BENCHMARK_STATUS]
-                == build.FunctionStatus.SUCCESSFUL.value
+                == build.FunctionStatus.SUCCESSFUL
             ):
                 printing.log_warning(
                     f"Skipping because it was already successfully benchmarked: {build_name}"
@@ -260,7 +259,7 @@ def benchmark_cache(
             elif (
                 skip_policy == "failed"
                 and eval_stats[fs.Keys.BENCHMARK_STATUS]
-                != build.FunctionStatus.SUCCESSFUL.value
+                != build.FunctionStatus.SUCCESSFUL
             ):
                 printing.log_warning(
                     f"Skipping because it was previously attempted and failed: {build_name}"
@@ -287,7 +286,7 @@ def benchmark_cache(
                 child.kill()
             parent.kill()
             stats.save_model_eval_stat(
-                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.TIMEOUT.value
+                fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.TIMEOUT
             )
 
             printing.log_warning(
@@ -304,11 +303,11 @@ def benchmark_cache(
 
             if isinstance(p.exception[0], SkippedBenchmark):
                 stats.save_model_eval_stat(
-                    fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED.value
+                    fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.NOT_STARTED
                 )
             else:
                 stats.save_model_eval_stat(
-                    fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.ERROR.value
+                    fs.Keys.BENCHMARK_STATUS, build.FunctionStatus.ERROR
                 )
 
             if isinstance(p.exception[0], exp.HardwareError):

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -133,7 +133,7 @@ def benchmark_build(
             build_name=build_name,
             stats=stats,
             iterations=iterations,
-            model=state.results[0],
+            model=state.results,
             # The `inputs` argument to BaseRT is only meant for
             # benchmarking runtimes that have to keep their inputs
             # in memory (e.g., `torch-eager`). We provide None here

--- a/src/turnkeyml/run/benchmark_build.py
+++ b/src/turnkeyml/run/benchmark_build.py
@@ -84,7 +84,7 @@ def benchmark_build(
         rt_args: same as turnkey
     """
 
-    state = build.load_state(cache_dir, build_name)
+    state = fs.load_state(cache_dir, build_name)
 
     if state.build_status != build.FunctionStatus.SUCCESSFUL:
         raise SkippedBenchmark(
@@ -93,7 +93,7 @@ def benchmark_build(
             f"has state: {state.build_status}"
         )
 
-    selected_runtime = apply_default_runtime(state.config.device, runtime)
+    selected_runtime = apply_default_runtime(state.device, runtime)
 
     if rt_args is None:
         rt_args_to_use = {}
@@ -140,7 +140,7 @@ def benchmark_build(
             # because this function only works with runtimes that
             # keep their model and inputs on disk.
             inputs=None,
-            device_type=state.config.device,
+            device_type=state.device,
             runtime=selected_runtime,
             **rt_args_to_use,
         )
@@ -231,7 +231,7 @@ def benchmark_cache(
                 "Try running `turnkey cache list` to see the builds in your build cache."
             )
 
-        state = build.load_state(cache_dir, build_name)
+        state = fs.load_state(cache_dir, build_name)
         stats = fs.Stats(cache_dir, build_name, state.evaluation_id)
 
         # Apply the skip policy by skipping over this iteration of the

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -119,7 +119,7 @@ def custom_stage():
 
             print(f"funny message: {self.funny_saying}")
 
-            state.intermediate_results = [output_onnx]
+            state.intermediate_results = output_onnx
 
             return state
 
@@ -161,7 +161,7 @@ class FullyCustomStage(stage.Stage):
     def fire(self, state):
         print(self.saying)
 
-        state.intermediate_results = ["great stuff"]
+        state.intermediate_results = "great stuff"
 
         return state
 

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -161,6 +161,8 @@ class FullyCustomStage(stage.Stage):
     def fire(self, state):
         print(self.saying)
 
+        state.intermediate_results = ["great stuff"]
+
         return state
 
 

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -111,7 +111,7 @@ def custom_stage():
             self.funny_saying = funny_saying
 
         def fire(self, state):
-            input_onnx = state.intermediate_results[0]
+            input_onnx = state.intermediate_results
             output_onnx = os.path.join(export.onnx_dir(state), "custom.onnx")
             fp32_model = load_model(input_onnx)
             fp16_model = convert_float_to_float16(fp32_model)
@@ -438,7 +438,7 @@ class Testing(unittest.TestCase):
 
         assert state.build_status == build.FunctionStatus.SUCCESSFUL
 
-        onnx_model = onnx.load(state.results[0])
+        onnx_model = onnx.load(state.results)
         model_opset = getattr(onnx_model.opset_import[0], "version", None)
         assert user_opset == model_opset
 

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -499,7 +499,7 @@ class Testing(unittest.TestCase):
         assert user_opset == model_opset
 
         # Make sure the ONNX file matches the state file
-        assert model_opset == state.config.onnx_opset
+        assert model_opset == state.onnx_opset
 
     def test_017_inputs_conversion(self):
         custom_sequence_fp32 = stage.Sequence(

--- a/test/cli.py
+++ b/test/cli.py
@@ -91,7 +91,7 @@ def assert_success_of_builds(
                     assert iterations == check_iteration_count
 
                 if check_opset:
-                    onnx_model = onnx.load(build_state.results[0])
+                    onnx_model = onnx.load(build_state.results)
                     model_opset = getattr(onnx_model.opset_import[0], "version", None)
                     assert model_opset == check_opset
 

--- a/test/cli.py
+++ b/test/cli.py
@@ -70,7 +70,7 @@ def assert_success_of_builds(
 
         for build_state_file in builds:
             if test_script_name in build_state_file:
-                build_state = build.load_state(state_path=build_state_file)
+                build_state = fs.load_state(state_path=build_state_file)
                 stats = filesystem.Stats(
                     build_state.cache_dir,
                     build_state.config.build_name,
@@ -479,7 +479,7 @@ class Testing(unittest.TestCase):
             turnkeycli()
 
         # Ensure test failed
-        build_state = build.load_state(state_path=filesystem.get_all(cache_dir)[0])
+        build_state = fs.load_state(state_path=filesystem.get_all(cache_dir)[0])
         assert build_state.build_status != build.FunctionStatus.SUCCESSFUL
 
         # Generate report

--- a/test/cli.py
+++ b/test/cli.py
@@ -18,11 +18,8 @@ import platform
 import torch
 from turnkeyml.cli.cli import main as turnkeycli
 import turnkeyml.cli.report as report
-import turnkeyml.common.filesystem as filesystem
-from turnkeyml.run.onnxrt.runtime import OnnxRT
-from turnkeyml.run.tensorrt.runtime import TensorRT
+import turnkeyml.common.filesystem as fs
 import turnkeyml.common.build as build
-import turnkeyml.common.filesystem as filesystem
 import turnkeyml.common.exceptions as exceptions
 import turnkeyml.build.export as export
 import turnkeyml.cli.spawn as spawn
@@ -61,7 +58,7 @@ def assert_success_of_builds(
 ) -> int:
     # Figure out the build name by surveying the build cache
     # for a build that includes test_script_name in the name
-    builds = filesystem.get_all(cache_dir)
+    builds = fs.get_all(cache_dir)
     builds_found = 0
 
     for test_script in test_script_files:
@@ -71,9 +68,9 @@ def assert_success_of_builds(
         for build_state_file in builds:
             if test_script_name in build_state_file:
                 build_state = fs.load_state(state_path=build_state_file)
-                stats = filesystem.Stats(
+                stats = fs.Stats(
                     build_state.cache_dir,
-                    build_state.config.build_name,
+                    build_state.build_name,
                     build_state.evaluation_id,
                 )
                 assert build_state.build_status == build.FunctionStatus.SUCCESSFUL
@@ -127,7 +124,7 @@ input_tensor = torch.rand(10)
 
 class Testing(unittest.TestCase):
     def setUp(self) -> None:
-        filesystem.rmdir(cache_dir)
+        fs.rmdir(cache_dir)
 
         return super().setUp()
 
@@ -301,9 +298,7 @@ class Testing(unittest.TestCase):
         # Make sure we can print the builds in the cache
         for test_script in common.test_scripts_dot_py.keys():
             test_script_path = os.path.join(corpus_dir, test_script)
-            builds, script_name = filesystem.get_builds_from_file(
-                cache_dir, test_script_path
-            )
+            builds, script_name = fs.get_builds_from_file(cache_dir, test_script_path)
 
             for build_name in builds:
                 # Make sure each build can be accessed with `turnkey cache stats`
@@ -431,7 +426,7 @@ class Testing(unittest.TestCase):
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
 
-        state_files = [Path(p).stem for p in filesystem.get_all(cache_dir)]
+        state_files = [Path(p).stem for p in fs.get_all(cache_dir)]
         assert state_files == ["linear_d5b1df11_state"]
 
         # Delete the builds
@@ -446,7 +441,7 @@ class Testing(unittest.TestCase):
         with patch.object(sys, "argv", testargs):
             turnkeycli()
 
-        assert filesystem.get_all(cache_dir) == []
+        assert fs.get_all(cache_dir) == []
 
         # Only build models labels with test_group::a and test_group::b
         testargs = [
@@ -462,7 +457,7 @@ class Testing(unittest.TestCase):
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
 
-        state_files = [Path(p).stem for p in filesystem.get_all(cache_dir)]
+        state_files = [Path(p).stem for p in fs.get_all(cache_dir)]
         assert state_files == ["linear_d5b1df11_state", "linear2_80b93950_state"]
 
     @unittest.skip("Needs re-implementation")
@@ -479,7 +474,7 @@ class Testing(unittest.TestCase):
             turnkeycli()
 
         # Ensure test failed
-        build_state = fs.load_state(state_path=filesystem.get_all(cache_dir)[0])
+        build_state = fs.load_state(state_path=fs.get_all(cache_dir)[0])
         assert build_state.build_status != build.FunctionStatus.SUCCESSFUL
 
         # Generate report
@@ -797,6 +792,7 @@ class Testing(unittest.TestCase):
             builds_found == 3
         ), f"Expected 3 builds (1 for linear.py, 2 for linear2.py), but got {builds_found}."
 
+    @unittest.skip("Flaky test https://github.com/onnx/turnkeyml/issues/58")
     def test_025_cli_timeout(self):
         """
         Make sure that the --timeout option and its associated reporting features work.
@@ -976,7 +972,7 @@ class Testing(unittest.TestCase):
             turnkeycli()
 
         # Benchmark the single model from cache directory
-        selected_build = filesystem.get_available_builds(cache_dir)[-1]
+        selected_build = fs.get_available_builds(cache_dir)[-1]
         testargs = [
             "turnkey",
             "cache",

--- a/test/helpers/common.py
+++ b/test/helpers/common.py
@@ -1,8 +1,7 @@
 import os
 import shutil
 from typing import Dict
-import turnkeyml.common.filesystem as filesystem
-import turnkeyml.common.build as build
+import turnkeyml.common.filesystem as fs
 
 
 # We generate a corpus on to the filesystem during the test
@@ -133,13 +132,13 @@ def get_stats_and_state(
     cache_dir: str,
 ) -> int:
     # Figure out the build name by surveying the build cache
-    builds = filesystem.get_all(cache_dir)
+    builds = fs.get_all(cache_dir)
     test_script_name = strip_dot_py(test_script)
 
     for build_state_file in builds:
         if test_script_name in build_state_file:
             build_state = fs.load_state(state_path=build_state_file)
-            stats = filesystem.Stats(
+            stats = fs.Stats(
                 build_state.cache_dir,
                 build_state.build_name,
                 build_state.evaluation_id,

--- a/test/helpers/common.py
+++ b/test/helpers/common.py
@@ -141,7 +141,7 @@ def get_stats_and_state(
             build_state = fs.load_state(state_path=build_state_file)
             stats = filesystem.Stats(
                 build_state.cache_dir,
-                build_state.config.build_name,
+                build_state.build_name,
                 build_state.evaluation_id,
             )
             return stats.evaluation_stats, build_state

--- a/test/helpers/common.py
+++ b/test/helpers/common.py
@@ -138,7 +138,7 @@ def get_stats_and_state(
 
     for build_state_file in builds:
         if test_script_name in build_state_file:
-            build_state = build.load_state(state_path=build_state_file)
+            build_state = fs.load_state(state_path=build_state_file)
             stats = filesystem.Stats(
                 build_state.cache_dir,
                 build_state.config.build_name,

--- a/test/plugins.py
+++ b/test/plugins.py
@@ -44,8 +44,8 @@ class Testing(unittest.TestCase):
         # Check if default part and config were assigned
         expected_device = "example_family::part1::config1"
         assert (
-            build_state.config.device == expected_device
-        ), f"Got {build_state.config.device}, expected {expected_device}"
+            build_state.device == expected_device
+        ), f"Got {build_state.device}, expected {expected_device}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #152 by making the State class a lot more flexible. 

Design considerations:
1. **The main intention here was to eliminate the breaking changes and crashes that could result from making simple changes to the State class.**
1. It turned out to be nice to keep a State class after all, since it can provide self-initialization and helper methods that a `Dict` would not.
1. It turns out we cant get rid of `state.yaml` entirely because we still need it for assessing cache hits/misses.

Big changes:
- `State` has been flattened and generalized. 
  - There are far fewer hardcoded members.
  - Developers can add new members to `State` by assigning them as attributes, ie `state.new_member = value`.
  - There is no more `Config` class (e.g., `build_name` is now in `state.build_name` instead of `state.config.build_name`.
  - `State` is no longer a `dataclass`
- `State` is self-initializing and no longer relies on external functions in `ignition` to set its defaults.


Smaller changes:
- Most `Enum`s have been converted to regular classes. 
  - This allows us to safely save and load their values from YAML without worrying about converting to and from the Enum class.
  - Lots of `.value` statements have been removed.

- `State.results` is no longer a list. It simply contains whatever result a `Stage` wants to produce. Code should stop referencing `results[0]` or setting `results = [output]`.
- `State` has been moved to `common.filesystem` to avoid circular imports.
  - Unified import of `filesystem` to `fs` in all modules (some did `import ... as filesystem`, now they are all `import ... as fs`)
  - Results in lots of changed of `import build` to `import filesystem as fs`