### PR TITLE
Transition benchmarking into a stage

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install dist/*.whl
           models=$(turnkey models-location --quiet)
-          turnkey -i $models/selftest/linear.py export-pytorch
+          turnkey -i $models/selftest/linear.py export-pytorch benchmark
       - name: Publish distribution package to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -55,15 +55,15 @@ jobs:
           rm -rf ~/.cache/turnkey
           python examples/files_api/onnx_opset.py --onnx-opset 15
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/scripts/hello_world.py export-pytorch
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch benchmark
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/scripts/multiple_invocations.py export-pytorch
+          turnkey -i examples/cli/scripts/multiple_invocations.py export-pytorch benchmark
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/scripts/max_depth.py --max-depth 1 export-pytorch
+          turnkey -i examples/cli/scripts/max_depth.py --max-depth 1 export-pytorch benchmark
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/scripts/two_models.py export-pytorch
+          turnkey -i examples/cli/scripts/two_models.py export-pytorch benchmark
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/onnx/hello_world.onnx export-pytorch
+          turnkey -i examples/cli/onnx/hello_world.onnx export-pytorch benchmark
 
           # E2E tests
           cd test/
@@ -74,19 +74,19 @@ jobs:
         run: |
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_rt
-          turnkey -i examples/cli/scripts/hello_world.py --runtime example-rt export-pytorch
+          turnkey -i examples/cli/scripts/hello_world.py --runtime example-rt export-pytorch benchmark
 
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_stage
-          turnkey -i examples/cli/scripts/hello_world.py  export-pytorch example-plugin-stage
+          turnkey -i examples/cli/scripts/hello_world.py  export-pytorch example-plugin-stage benchmark
 
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_combined
-          turnkey -i examples/cli/scripts/hello_world.py --runtime example-combined-rt --rt-args delay_before_benchmarking::5 export-pytorch combined-example-stage
-          turnkey -i examples/cli/scripts/hello_world.py --device example_family::part1::config2 export-pytorch combined-example-stage
-          turnkey -i examples/cli/scripts/hello_world.py --device example_family::part1::config1 export-pytorch combined-example-stage
-          turnkey -i examples/cli/scripts/hello_world.py --device example_family::part1 export-pytorch combined-example-stage
-          turnkey -i examples/cli/scripts/hello_world.py --device example_family export-pytorch combined-example-stage
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --runtime example-combined-rt --rt-args delay_before_benchmarking::5
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark benchmark --device example_family::part1::config2 
+          turnkey -i examples/cli/scripts/hello_world.pyexport-pytorch combined-example-stage benchmark --device example_family::part1::config1 
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1 
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family 
 
           # E2E tests
           cd test

--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -84,7 +84,7 @@ jobs:
           pip install -e examples/cli/plugins/example_combined
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --runtime example-combined-rt --rt-args delay_before_benchmarking::5
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark benchmark --device example_family::part1::config2 
-          turnkey -i examples/cli/scripts/hello_world.pyexport-pytorch combined-example-stage benchmark --device example_family::part1::config1 
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1::config1 
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1 
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family 
 

--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_rt
-          turnkey -i examples/cli/scripts/hello_world.py --runtime example-rt export-pytorch benchmark
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch benchmark --runtime example-rt
 
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_stage

--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -114,7 +114,7 @@ jobs:
 
           # Run tests on Slurm
           export TURNKEY_SLURM_USE_DEFAULT_MEMORY="True"
-          turnkey -i models/selftest/linear.py --build-only --use-slurm --cache-dir local_cache export-pytorch
+          turnkey -i models/selftest/linear.py --use-slurm --cache-dir local_cache export-pytorch
           bash test/helpers/check_slurm_output.sh slurm-2.out
 
       # Below tests are commented out as the GitHub runner runs out of space installing the requirements

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -176,7 +176,7 @@ class OnnxLoad(stage.Stage):
         fail_msg = "\tFailed receiving ONNX Model"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = output_path
+            state.results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(
@@ -363,7 +363,7 @@ class ExportPytorchModel(stage.Stage):
         fail_msg = "\tFailed exporting model to ONNX"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = output_path
+            state.results = output_path
 
             stats.save_model_eval_stat(
                 fs.Keys.ONNX_FILE,
@@ -388,7 +388,7 @@ class OptimizeOnnxModel(stage.Stage):
     node eliminations, Semantics-preserving node fusions
 
     Expected inputs:
-     - state.intermediate_results contains a single .onnx file
+     - state.results contains a single .onnx file
 
     Outputs:
      - A *-opt.onnx file
@@ -409,7 +409,7 @@ class OptimizeOnnxModel(stage.Stage):
         return parser
 
     def fire(self, state: fs.State):
-        input_onnx = state.intermediate_results
+        input_onnx = state.results
         output_path = opt_onnx_file(state)
 
         # Perform some basic optimizations on the model to remove shape related
@@ -434,7 +434,7 @@ class OptimizeOnnxModel(stage.Stage):
         fail_msg = "\tFailed optimizing ONNX model"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = output_path
+            state.results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(
@@ -459,7 +459,7 @@ class ConvertOnnxToFp16(stage.Stage):
     to fp16.
 
     Expected inputs:
-     - state.intermediate_results contains a single .onnx file
+     - state.results contains a single .onnx file
 
     Outputs:
      - A *-f16.onnx file with FP16 trained parameters
@@ -482,7 +482,7 @@ class ConvertOnnxToFp16(stage.Stage):
         return parser
 
     def fire(self, state: fs.State):
-        input_onnx = state.intermediate_results
+        input_onnx = state.results
 
         # Convert the model to FP16
         # Some ops will not be converted to fp16 because they are in a block list
@@ -548,7 +548,7 @@ class ConvertOnnxToFp16(stage.Stage):
         fail_msg = "\tFailed converting ONNX model to fp16"
 
         if check_model(output_path, success_msg, fail_msg):
-            state.intermediate_results = output_path
+            state.results = output_path
 
             stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
             stats.save_model_eval_stat(

--- a/src/turnkeyml/build/ignition.py
+++ b/src/turnkeyml/build/ignition.py
@@ -44,7 +44,6 @@ def validate_cached_model(
     # should be listed here.
     cache_analysis_properties = [
         fs.Keys.BUILD_NAME,
-        fs.Keys.DEVICE,
         fs.Keys.SEQUENCE_INFO,
         fs.Keys.BUILD_STATUS,
         fs.Keys.TURNKEY_VERSION,
@@ -119,7 +118,6 @@ def validate_cached_model(
     changed_args = []
     for key in [
         fs.Keys.BUILD_NAME,
-        fs.Keys.DEVICE,
         fs.Keys.SEQUENCE_INFO,
     ]:
         if vars(new_state)[key] != vars(cached_state)[key]:

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -2,7 +2,6 @@ import abc
 import sys
 import time
 import os
-import copy
 import argparse
 from typing import List, Tuple, Dict
 from multiprocessing import Process

--- a/src/turnkeyml/build/stage_plugins.py
+++ b/src/turnkeyml/build/stage_plugins.py
@@ -1,7 +1,8 @@
 import turnkeyml.build.export as export
 import turnkeyml.common.plugins as plugins
 import turnkeyml.common.management_tools as mgmt
-import turnkeyml.run.benchmark_build as bench
+from turnkeyml.run.benchmark_build import BenchmarkBuild
+from turnkeyml.run.benchmark_model import Benchmark
 import turnkeyml.cli.report as report
 
 # Plugin interface for sequences
@@ -13,7 +14,8 @@ SUPPORTED_STAGES = [
     mgmt.Cache,
     mgmt.ModelsLocation,
     report.Report,
-    bench.BenchmarkBuild,
+    BenchmarkBuild,
+    Benchmark,
     export.ExportPytorchModel,
     export.OptimizeOnnxModel,
     export.OnnxLoad,

--- a/src/turnkeyml/build_api.py
+++ b/src/turnkeyml/build_api.py
@@ -15,7 +15,6 @@ def build_model(
     cache_dir: str = fs.DEFAULT_CACHE_DIR,
     monitor: Optional[bool] = None,
     rebuild: Optional[str] = None,
-    device: Optional[str] = None,
 ) -> fs.State:
     """Use build a model instance into an optimized ONNX file.
 
@@ -42,10 +41,6 @@ def build_model(
             - "never": load cached builds without checking validity, with no guarantee
                 of functionality or correctness
             - None: Falls back to default
-        device: Specific device target to take into account during the build sequence.
-            Use the format "device_family", "device_family::part", or
-            "device_family::part::configuration" to refer to a family of devices,
-            part within a family, or configuration of a part model, respectively.
 
         More information is available in the Tools User Guide:
             https://github.com/onnx/turnkeyml/blob/main/docs/tools_user_guide.md
@@ -72,7 +67,6 @@ def build_model(
         cache_dir=cache_dir,
         build_name=build_name,
         sequence_info=sequence.info,
-        device=device,
     )
 
     # Get the state of the model from the cache if a valid build is available

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -7,14 +7,13 @@ from typing import List
 import turnkeyml.common.filesystem as fs
 from turnkeyml.build.stage import Stage, Sequence
 from turnkeyml.build.stage_plugins import SUPPORTED_STAGES
-from turnkeyml.run.devices import SUPPORTED_DEVICES, SUPPORTED_RUNTIMES
+
 from turnkeyml.cli.spawn import DEFAULT_TIMEOUT_SECONDS
 from turnkeyml.files_api import benchmark_files
 from turnkeyml.analyze.status import Verbosity
 import turnkeyml.common.build as build
 import turnkeyml.common.exceptions as exp
 from turnkeyml.common.management_tools import ManagementTool
-import turnkeyml.cli.parser_helpers as parser_helpers
 
 
 class PreserveWhiteSpaceWrapRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter):
@@ -129,14 +128,6 @@ Management tool choices:
     )
 
     parser.add_argument(
-        "-b",
-        "--build-only",
-        dest="build_only",
-        help="Stop this command after the analyze and build phases",
-        action="store_true",
-    )
-
-    parser.add_argument(
         "--labels",
         dest="labels",
         help="Only benchmark the scripts that have the provided labels",
@@ -159,29 +150,6 @@ Management tool choices:
         help="Maximum depth to analyze within the model structure of the target script(s)",
     )
 
-    benchmark_default_device = "x86"
-    parser.add_argument(
-        "--device",
-        choices=SUPPORTED_DEVICES,
-        dest="device",
-        help="Type of hardware device to be used for the benchmark "
-        f'(defaults to "{benchmark_default_device}")',
-        required=False,
-        default=benchmark_default_device,
-    )
-
-    parser.add_argument(
-        "--runtime",
-        choices=SUPPORTED_RUNTIMES.keys(),
-        dest="runtime",
-        help="Software runtime that will be used to collect the benchmark. "
-        "Must be compatible with the selected device. "
-        "Automatically selects a sequence if `--sequence` is not used. "
-        "If this argument is not set, the default runtime of the selected device will be used.",
-        required=False,
-        default=None,
-    )
-
     parser.add_argument(
         "--rebuild",
         choices=build.REBUILD_OPTIONS,
@@ -189,23 +157,6 @@ Management tool choices:
         help=f"Sets the cache rebuild policy (defaults to {build.DEFAULT_REBUILD_POLICY})",
         required=False,
         default=build.DEFAULT_REBUILD_POLICY,
-    )
-
-    parser.add_argument(
-        "--iterations",
-        dest="iterations",
-        type=int,
-        default=100,
-        help="Number of execution iterations of the model to capture\
-              the benchmarking performance (e.g., mean latency)",
-    )
-
-    parser.add_argument(
-        "--rt-args",
-        dest="rt_args",
-        type=str,
-        nargs="*",
-        help="Optional arguments provided to the runtime being used",
     )
 
     slurm_or_processes_group = parser.add_mutually_exclusive_group()
@@ -294,9 +245,6 @@ Management tool choices:
             "Calls to tunrkey are required to call at least "
             "one stage or management tool."
         )
-
-    # Decode CLI arguments before calling the API
-    global_args["rt_args"] = parser_helpers.decode_args(global_args["rt_args"])
 
     # Convert stage names into Stage instaces
     stage_instances = {

--- a/src/turnkeyml/cli/report.py
+++ b/src/turnkeyml/cli/report.py
@@ -127,10 +127,7 @@ class Report(ManagementTool):
                                 # reporting time, it must have been killed by a time out,
                                 # out-of-memory (OOM), or some other uncaught exception
                                 if (
-                                    (
-                                        key == fs.Keys.BUILD_STATUS
-                                        or fs.Keys.BENCHMARK_STATUS
-                                    )
+                                    key == fs.Keys.BUILD_STATUS
                                     or fs.Keys.STAGE_STATUS in key
                                 ) and value == build.FunctionStatus.INCOMPLETE:
                                     value = build.FunctionStatus.KILLED

--- a/src/turnkeyml/common/build.py
+++ b/src/turnkeyml/common/build.py
@@ -39,10 +39,6 @@ class ModelType:
     UNKNOWN = "unknown"
 
 
-# Indicates that the build should take take any specific device into account
-DEFAULT_DEVICE = "default"
-
-
 def load_yaml(file_path) -> Dict:
     with open(file_path, "r", encoding="utf8") as stream:
         try:

--- a/src/turnkeyml/common/filesystem.py
+++ b/src/turnkeyml/common/filesystem.py
@@ -312,8 +312,6 @@ class Keys:
     MODEL_SCRIPT = "builtin_model_script"
     # Indicates status of the most recent build tool run: FunctionStatus
     BUILD_STATUS = "build_status"
-    # Indicates status of the most recent benchmark tool run: FunctionStatus
-    BENCHMARK_STATUS = "benchmark_status"
     # Indicates the match between the TorchScript IR graph and
     # the exported onnx model (verified with torch.onnx.verification)
     TORCH_ONNX_EXPORT_VALIDITY = "torch_export_validity"
@@ -353,6 +351,8 @@ class Keys:
     DOWNCAST_APPLIED = "downcast_applied"
     # Directory where the turnkey build cache is stored
     CACHE_DIR = "cache_dir"
+    # Example inputs to the model
+    INPUTS = "inputs"
 
 
 def _clean_logfile(logfile_lines: List[str]) -> List[str]:
@@ -556,7 +556,6 @@ class State:
         monitor: Optional[bool] = None,
         build_name: Optional[str] = None,
         sequence_info: Dict[str, Dict] = None,
-        device: Optional[str] = None,
         **kwargs,
     ):
 
@@ -573,11 +572,6 @@ class State:
         if build_name is None:
             build_name = os.path.basename(sys.argv[0])
 
-        if device is None:
-            device_to_use = build.DEFAULT_DEVICE
-        else:
-            device_to_use = device
-
         # Support "~" in the cache_dir argument
         parsed_cache_dir = os.path.expanduser(cache_dir)
 
@@ -590,7 +584,6 @@ class State:
         self.cache_dir = parsed_cache_dir
         self.build_name = build_name
         self.sequence_info = sequence_info
-        self.device = device_to_use
         self.turnkey_version = turnkey_version
         self.build_status = build.FunctionStatus.NOT_STARTED
         self.downcast_applied = False

--- a/src/turnkeyml/common/performance.py
+++ b/src/turnkeyml/common/performance.py
@@ -5,7 +5,9 @@ import turnkeyml.common.exceptions as exp
 
 
 class Device:
-    def __init__(self, selected_device: str, rt_supported_devices: Optional[Dict] = None):
+    def __init__(
+        self, selected_device: str, rt_supported_devices: Optional[Dict] = None
+    ):
         self.family: str
         self.part: Optional[str] = None
         self.config: Optional[str] = None
@@ -21,11 +23,11 @@ class Device:
 
         # Set family, part, and config straight away if rt_supported_devices is not provided
         if rt_supported_devices is None:
-            if len(values)>0:
+            if len(values) > 0:
                 self.family = values[0]
-            if len(values)>1:
+            if len(values) > 1:
                 self.part = values[1]
-            if len(values)>2:
+            if len(values) > 2:
                 self.config = values[2]
             return
 
@@ -50,13 +52,13 @@ class Device:
             if values[1] in rt_supported_devices[self.family]:
                 self.part = values[1]
             elif len(rt_supported_devices[self.family]) == 0:
-                raise exp.ArgError(
-                    f"Device family {self.family} supports no parts."
-                )
+                raise exp.ArgError(f"Device family {self.family} supports no parts.")
             else:
                 error_msg = f"Part {values[1]} is not supported by this device family."
                 if len(rt_supported_devices[self.family]) > 0:
-                    error_msg += f" Supported parts are: {rt_supported_devices[self.family]}"
+                    error_msg += (
+                        f" Supported parts are: {rt_supported_devices[self.family]}"
+                    )
                 raise exp.ArgError(error_msg)
         elif rt_supported_devices[self.family]:
             self.part = next(iter(rt_supported_devices[self.family]))
@@ -97,14 +99,14 @@ class MeasuredPerformance:
     device_type: Union[str, Device]
     build_name: str
     throughput_units: str = "inferences per second (IPS)"
-    latency_units: str = "milliseconds (ms)"
+    mean_latency_units: str = "milliseconds (ms)"
 
     def print(self):
         printing.log_info(
             f"\nPerformance of build {self.build_name} on {self.device} "
             f"({self.runtime} v{self.runtime_version}) is:"
         )
-        print(f"\tMean Latency: {self.mean_latency:.3f} {self.latency_units}")
+        print(f"\tMean Latency: {self.mean_latency:.3f} {self.mean_latency_units}")
         print(f"\tThroughput: {self.throughput:.1f} {self.throughput_units}")
         print()
 

--- a/src/turnkeyml/files_api.py
+++ b/src/turnkeyml/files_api.py
@@ -223,13 +223,6 @@ def benchmark_files(
             Action.BUILD,
         ]
 
-    if Action.BENCHMARK in actions:
-        printing.log_warning(
-            "The benchmarking functionality of ONNX TurnkeyML has been "
-            "deprecated. See https://github.com/onnx/turnkeyml/milestone/3 "
-            "for details."
-        )
-
     if use_slurm:
         jobs = spawn.slurm_jobs_in_queue()
         if len(jobs) > 0:

--- a/src/turnkeyml/run/benchmark_model.py
+++ b/src/turnkeyml/run/benchmark_model.py
@@ -1,0 +1,190 @@
+import argparse
+from typing import Optional
+import turnkeyml.build.stage as stage
+import turnkeyml.common.exceptions as exp
+import turnkeyml.common.filesystem as fs
+from turnkeyml.run.devices import (
+    SUPPORTED_RUNTIMES,
+    SUPPORTED_DEVICES,
+    apply_default_runtime,
+)
+import turnkeyml.cli.parser_helpers as parser_helpers
+from turnkeyml.common.performance import Device
+
+default_iterations = 100
+benchmark_default_device = "x86"
+
+
+class Benchmark(stage.Stage):
+    """
+    Stage that benchmarks a model based on the selected device and runtime.
+
+    Expected inputs:
+     - state.results is a model to be benchmarked
+
+    Outputs: None
+    """
+
+    unique_name = "benchmark"
+
+    def __init__(self):
+        super().__init__(monitor_message="Benchmarking model")
+
+        self.status_stats = ["throughput", "mean_latency"]
+
+    @staticmethod
+    def parser(add_help: bool = True) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            description="Benchmark a model",
+            add_help=add_help,
+        )
+
+        parser.add_argument(
+            "--device",
+            choices=SUPPORTED_DEVICES,
+            dest="device",
+            help="Type of hardware device to be used for the benchmark "
+            f'(defaults to "{benchmark_default_device}")',
+            required=False,
+            default=benchmark_default_device,
+        )
+
+        parser.add_argument(
+            "--runtime",
+            choices=SUPPORTED_RUNTIMES.keys(),
+            dest="runtime",
+            help="Software runtime that will be used to collect the benchmark. "
+            "Must be compatible with the selected device. "
+            "Automatically selects a sequence if `--sequence` is not used. "
+            "If this argument is not set, the default runtime of the selected device will be used.",
+            required=False,
+            default=None,
+        )
+
+        parser.add_argument(
+            "--iterations",
+            dest="iterations",
+            type=int,
+            default=default_iterations,
+            help="Number of execution iterations of the model to capture\
+                the benchmarking performance (e.g., mean latency)",
+        )
+
+        parser.add_argument(
+            "--rt-args",
+            dest="rt_args",
+            type=str,
+            nargs="*",
+            help="Optional arguments provided to the runtime being used",
+        )
+
+        return parser
+
+    def parse(self, state: fs.State, args, known_only=True) -> argparse.Namespace:
+        parsed_args = super().parse(state, args, known_only)
+
+        parsed_args.rt_args = parser_helpers.decode_args(parsed_args.rt_args)
+
+        return parsed_args
+
+    def fire(
+        self,
+        state: fs.State,
+        device: str = benchmark_default_device,
+        runtime: str = None,
+        iterations: int = default_iterations,
+        rt_args: Optional[str] = None,
+    ):
+
+        stats = fs.Stats(state.cache_dir, state.build_name, state.evaluation_id)
+
+        selected_runtime = apply_default_runtime(device, runtime)
+
+        # Get the default part and config by providing the Device class with
+        # the supported devices by the runtime
+        runtime_supported_devices = SUPPORTED_RUNTIMES[selected_runtime][
+            "supported_devices"
+        ]
+        specific_device = str(Device(device, runtime_supported_devices))
+
+        if rt_args is None:
+            rt_args_to_use = {}
+        else:
+            rt_args_to_use = rt_args
+
+        try:
+            runtime_info = SUPPORTED_RUNTIMES[selected_runtime]
+        except KeyError as e:
+            # User should never get this far without hitting an actionable error message,
+            # but let's raise an exception just in case.
+            raise exp.StageError(
+                f"Selected runtime is not supported: {selected_runtime}"
+            ) from e
+
+        # Save the device name that will be used for the benchmark
+        stats.save_model_eval_stat(
+            fs.Keys.DEVICE, runtime_info["RuntimeClass"].device_name()
+        )
+
+        # Save specific information into its own key for easier access
+        stats.save_model_eval_stat(
+            fs.Keys.DEVICE_TYPE,
+            specific_device,
+        )
+        stats.save_model_eval_stat(
+            fs.Keys.RUNTIME,
+            runtime,
+        )
+
+        stats.save_model_eval_stat(
+            fs.Keys.ITERATIONS,
+            iterations,
+        )
+
+        # Check whether the device and runtime are ready for use prior to
+        # running the benchmark
+        if "requirement_check" in runtime_info:
+            runtime_info["requirement_check"]()
+
+        # Each runtimes can contribute its own status stats
+        if runtime_info.get("status_stats"):
+            self.status_stats += runtime_info.get("status_stats")
+
+        # FIXME: this wont be necessary once Discovery is a stage and
+        # it passes state.results
+        if state.results:
+            model_to_use = state.results
+        else:
+            model_to_use = state.model
+
+        # Instantiate BaseRT for the selected runtime
+        runtime_handle = runtime_info["RuntimeClass"](
+            cache_dir=state.cache_dir,
+            build_name=state.build_name,
+            stats=stats,
+            iterations=iterations,
+            model=model_to_use,
+            # The `inputs` argument to BaseRT is only meant for
+            # benchmarking runtimes that have to keep their inputs
+            # in memory (e.g., `torch-eager`). We provide None here
+            # because this function only works with runtimes that
+            # keep their model and inputs on disk.
+            inputs=vars(state).get(fs.Keys.INPUTS),
+            device_type=specific_device,
+            runtime=selected_runtime,
+            **rt_args_to_use,
+        )
+        perf = runtime_handle.benchmark()
+
+        for key, value in vars(perf).items():
+            stats.save_model_eval_stat(
+                key=key,
+                value=value,
+            )
+
+        # Inform the user of the result
+        perf.print()
+
+        state.perf = perf
+
+        return state

--- a/src/turnkeyml/run/benchmark_model.py
+++ b/src/turnkeyml/run/benchmark_model.py
@@ -164,11 +164,6 @@ class Benchmark(stage.Stage):
             stats=stats,
             iterations=iterations,
             model=model_to_use,
-            # The `inputs` argument to BaseRT is only meant for
-            # benchmarking runtimes that have to keep their inputs
-            # in memory (e.g., `torch-eager`). We provide None here
-            # because this function only works with runtimes that
-            # keep their model and inputs on disk.
             inputs=vars(state).get(fs.Keys.INPUTS),
             device_type=specific_device,
             runtime=selected_runtime,

--- a/test/analysis.py
+++ b/test/analysis.py
@@ -217,7 +217,6 @@ class Testing(unittest.TestCase):
                 os.path.join(corpus_dir, "linear_pytorch.py::76af2f62"),
                 "--max-depth",
                 "1",
-                "--build-only",
                 "--cache-dir",
                 cache_dir,
                 "--verbosity",
@@ -239,7 +238,6 @@ class Testing(unittest.TestCase):
                 "--cache-dir",
                 cache_dir,
                 "--lean-cache",
-                "--build-only",
                 "--verbosity",
                 Verbosity.DYNAMIC.value,
                 "export-pytorch",
@@ -285,7 +283,8 @@ class Testing(unittest.TestCase):
             f"--num_channels {num_channels+1}",
             "--verbosity",
             Verbosity.DYNAMIC.value,
-            "export-pytorch",  # FIXME: add `benchmark` when Benchmarking is a stage
+            "export-pytorch",
+            "benchmark",
         ]
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, _ = process.communicate()
@@ -302,7 +301,8 @@ class Testing(unittest.TestCase):
             "--invalid_arg 123",
             "--verbosity",
             Verbosity.DYNAMIC.value,
-            "export-pytorch",  # FIXME: add `benchmark` when Benchmarking is a stage
+            "export-pytorch",
+            "benchmark",
         ]
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         _, stderr = process.communicate()
@@ -356,7 +356,6 @@ class Testing(unittest.TestCase):
                 "turnkey",
                 "-i",
                 os.path.join(corpus_dir, "linear_pytorch.py::76af2f62"),
-                "--build-only",
                 "--max-depth",
                 "1",
                 "--cache-dir",
@@ -379,7 +378,6 @@ class Testing(unittest.TestCase):
                 "1",
                 "--cache-dir",
                 cache_dir,
-                "--build-only",
                 "--verbosity",
                 Verbosity.DYNAMIC.value,
                 "export-pytorch",

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -132,7 +132,7 @@ def custom_stage():
             return parser
 
         def fire(self, state):
-            input_onnx = state.intermediate_results
+            input_onnx = state.results
             output_onnx = os.path.join(export.onnx_dir(state), "custom.onnx")
             fp32_model = load_model(input_onnx)
             fp16_model = convert_float_to_float16(fp32_model)
@@ -140,7 +140,7 @@ def custom_stage():
 
             print(f"funny message: {self.funny_saying}")
 
-            state.intermediate_results = output_onnx
+            state.results = output_onnx
 
             return state
 
@@ -190,7 +190,7 @@ class FullyCustomStage(stage.Stage):
     def fire(self, state):
         print(self.saying)
 
-        state.intermediate_results = "great stuff"
+        state.results = "great stuff"
 
         return state
 

--- a/test/cli.py
+++ b/test/cli.py
@@ -136,7 +136,6 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             os.path.join(corpus_dir, test_script),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -156,7 +155,6 @@ class Testing(unittest.TestCase):
             "-i",
             os.path.join(corpus_dir, test_scripts[0]),
             os.path.join(corpus_dir, test_scripts[1]),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -178,7 +176,6 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             bash(f"{corpus_dir}/*.py"),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -199,7 +196,6 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             bash(f"{corpus_dir}/*.py"),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -236,7 +232,6 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             bash(f"{corpus_dir}/*.py"),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -301,7 +296,6 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             bash(f"{corpus_dir}/*.py"),
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -398,7 +392,6 @@ class Testing(unittest.TestCase):
             os.path.join(corpus_dir, test_script),
             "--rebuild",
             "always",
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -423,6 +416,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -444,6 +438,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -472,7 +467,6 @@ class Testing(unittest.TestCase):
             bash(f"{corpus_dir}/*.py"),
             "--labels",
             "test_group::a,b",
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
@@ -489,12 +483,13 @@ class Testing(unittest.TestCase):
         testargs = [
             "turnkey",
             bash(f"{corpus_dir}/linear.py"),
-            "--device",
-            "reimplement_me",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
+            "--device",
+            "reimplement_me",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -537,12 +532,13 @@ class Testing(unittest.TestCase):
                 bash(f"{corpus_dir}/linear.py"),
                 "--cache-dir",
                 cache_dir,
+                "export-pytorch",
+                "optimize-onnx",
+                "benchmark",
                 "--device",
                 "x86",
                 "--runtime",
                 "trt",
-                "export-pytorch",
-                "optimize-onnx",
             ]
             with patch.object(sys, "argv", flatten(testargs)):
                 turnkeycli()
@@ -554,12 +550,11 @@ class Testing(unittest.TestCase):
             bash(f"{corpus_dir}/linear.py"),
             "--cache-dir",
             cache_dir,
+            "benchmark",
             "--device",
             "x86",
             "--runtime",
             "torch-eager",
-            # FIXME: remove/replace this when discovery/benchmarking are Stages
-            "export-pytorch",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -571,12 +566,13 @@ class Testing(unittest.TestCase):
             bash(f"{corpus_dir}/linear.py"),
             "--cache-dir",
             cache_dir,
+            "export-pytorch",
+            "optimize-onnx",
+            "benchmark",
             "--device",
             "x86",
             "--runtime",
             "ort",
-            "export-pytorch",
-            "optimize-onnx",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -600,6 +596,7 @@ class Testing(unittest.TestCase):
             "--opset",
             str(user_opset),
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -619,10 +616,11 @@ class Testing(unittest.TestCase):
             os.path.join(corpus_dir, test_script),
             "--cache-dir",
             cache_dir,
-            "--iterations",
-            str(test_iterations),
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
+            "--iterations",
+            str(test_iterations),
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -649,6 +647,7 @@ class Testing(unittest.TestCase):
                 "--process-isolation",
                 "export-pytorch",
                 "optimize-onnx",
+                "benchmark",
             ]
             with patch.object(sys, "argv", testargs):
                 turnkeycli()
@@ -683,6 +682,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -702,6 +702,7 @@ class Testing(unittest.TestCase):
                 "gobbledegook",
                 "export-pytorch",
                 "optimize-onnx",
+                "benchmark",
             ]
             with patch.object(sys, "argv", flatten(testargs)):
                 turnkeycli()
@@ -717,6 +718,7 @@ class Testing(unittest.TestCase):
             "--cache-dir",
             cache_dir,
             "export-pytorch",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -747,6 +749,7 @@ class Testing(unittest.TestCase):
             "--cache-dir",
             cache_dir,
             "onnx-load",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -781,6 +784,7 @@ class Testing(unittest.TestCase):
             "--cache-dir",
             cache_dir,
             "onnx-load",
+            "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -810,6 +814,7 @@ class Testing(unittest.TestCase):
                     filename,
                     "export-pytorch",
                     "optimize-onnx",
+                    "benchmark",
                 ]
                 with patch.object(sys, "argv", testargs):
                     turnkeycli()
@@ -825,6 +830,7 @@ class Testing(unittest.TestCase):
                     file_prefix,
                     "export-pytorch",
                     "optimize-onnx",
+                    "benchmark",
                 ]
                 with patch.object(sys, "argv", testargs):
                     turnkeycli()
@@ -840,7 +846,6 @@ class Testing(unittest.TestCase):
             os.path.join(extras_dir, "selected_models.txt"),
             "--cache-dir",
             cache_dir,
-            "--build-only",
             "export-pytorch",
             "optimize-onnx",
         ]
@@ -877,6 +882,7 @@ class Testing(unittest.TestCase):
             "--build-only",
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -924,6 +930,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -1028,7 +1035,6 @@ class Testing(unittest.TestCase):
             bash(f"{corpus_dir}/*.py"),
             "--cache-dir",
             cache_dir,
-            "--build-only",
             "export-pytorch",
             "optimize-onnx",
         ]

--- a/test/plugins.py
+++ b/test/plugins.py
@@ -27,27 +27,28 @@ class Testing(unittest.TestCase):
             "turnkey",
             "-i",
             os.path.join(corpus_dir, test_script),
-            "--device",
-            "example_family",
-            "--build-only",
             "--cache-dir",
             cache_dir,
             "export-pytorch",
             "optimize-onnx",
+            "benchmark",
+            "--device",
+            "example_family",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
 
-        _, build_state = common.get_stats_and_state(test_script, cache_dir)
+        build_stats, build_state = common.get_stats_and_state(test_script, cache_dir)
 
         # Check if build was successful
         assert build_state.build_status == build.FunctionStatus.SUCCESSFUL
 
         # Check if default part and config were assigned
         expected_device = "example_family::part1::config1"
+        actual_device = build_stats["device_type"]
         assert (
-            build_state.device == expected_device
-        ), f"Got {build_state.device}, expected {expected_device}"
+            actual_device == expected_device
+        ), f"Got {actual_device}, expected {expected_device}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #153 

# Major Changes
 - Benchmarking is now a stage called `benchmark`
   - Explicitly add `benchmark` to your turnkey command if you want a benchmark
       - ex: `turnkey -i $models/selftest/linear.py export-pytorch benchmark`
       - All benchmarking tests have been updated to add this
   - `--build-only` is no longer needed, just don't write `benchmark` if you don't want a benchmark
       - All non-benchmarking tests have removed `--build-only` 
 - The `benchmark` stage is the only way to do benchmarking now (no more redundant code paths)
   - Option 1: Benchmark in the sequence
   - Option 2 (the new `turnkey benchmark-build` implementation): invoke the `benchmark` stage as an API
     - **Note:** in the future these could converge further by adding a `load-build` stage. Then cache benchmarking would look like: `turnkey load-build -i cache/* benchmark` 
 - `device`, `runtime`, `iterations`, and `rt_args` are now arguments to the `benchmark` stage and are no longer global
   - `stage.device` removed
   - Discovery, the files API, and the status printout are no longer aware of device/runtime explicitly. This eliminated a lot of redundant and misplaced code.
   - Automatic runtime selection based on the device now takes place in the `benchmark` stage.
- The `benchmarking_status` key has been eliminated from stats.
  - Refer to `stage_status::benchmark` instead.  
  - This saves all the explicit code for tracking benchmarking status. It is now handled just like any other stage.
- **New feature**: any Stage can contribute `status_stats` to the status printout, not just benchmarking runtimes.
  - Any `status_stats` key can have have a corresponding `units` key whose value will get populated in the stats.
    - ex: Providing both `mean_latency` and `mean_latency_units` in the stats results in `Mean Latency: 0.011 milliseconds (ms)`
- The concept of `state.intermediate_results` has been eliminated. There is now just `state.results`. 

# (Minor) Regression

`turnkey -i model.py export-pytorch` followed by `turnkey -i model.py export-pytorch benchmark` will re-build the model because it is considered a cache miss. This miss is because any change to the sequence is considered a miss. Previously, the exported onnx model would have been loaded from cache.

Instead, if you want a cache hit, do: `turnkey -i model.py export-pytorch` `turnkey benchmark-build --build-names script`