### PR TITLE
Add guardrails to the CLI

### DIFF
--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -83,7 +83,7 @@ jobs:
           rm -rf ~/.cache/turnkey
           pip install -e examples/cli/plugins/example_combined
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --runtime example-combined-rt --rt-args delay_before_benchmarking::5
-          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark benchmark --device example_family::part1::config2 
+          turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1::config2 
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1::config1 
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family::part1 
           turnkey -i examples/cli/scripts/hello_world.py export-pytorch combined-example-stage benchmark --device example_family 

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -100,7 +100,7 @@ class OnnxLoad(stage.Stage):
 
     @staticmethod
     def parser(add_help: bool = True) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+        parser = __class__.helpful_parser(
             description="Load an ONNX model",
             add_help=add_help,
         )
@@ -215,7 +215,7 @@ class ExportPytorchModel(stage.Stage):
 
     @staticmethod
     def parser(add_help: bool = True) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+        parser = __class__.helpful_parser(
             description="Export a PyTorch model to ONNX",
             add_help=add_help,
         )
@@ -401,7 +401,7 @@ class OptimizeOnnxModel(stage.Stage):
 
     @staticmethod
     def parser(add_help: bool = True) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+        parser = __class__.helpful_parser(
             description="Use OnnxRuntime to optimize an ONNX model",
             add_help=add_help,
         )
@@ -474,7 +474,7 @@ class ConvertOnnxToFp16(stage.Stage):
 
     @staticmethod
     def parser(add_help: bool = True) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+        parser = __class__.helpful_parser(
             description="Use OnnxMLTools to convert an ONNX model to fp16",
             add_help=add_help,
         )

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -63,8 +63,8 @@ class StageParser(argparse.ArgumentParser):
                 # This was probably a misspelled stage name
                 message = message + (
                     f". If `{unrecognized}` was intended to invoke "
-                    "a stage, please run `turnkey -h` and check the spelling and availability of that "
-                    "stage."
+                    "a stage, please run `turnkey -h` and check the spelling and "
+                    "availability of that stage."
                 )
         self.print_usage()
         printing.log_error(message)

--- a/src/turnkeyml/build/stage.py
+++ b/src/turnkeyml/build/stage.py
@@ -55,9 +55,40 @@ def _name_is_file_safe(name: str):
             raise ValueError(msg)
 
 
+class StageParser(argparse.ArgumentParser):
+    def error(self, message):
+        if message.startswith("unrecognized arguments"):
+            unrecognized = message.split(": ")[1]
+            if not unrecognized.startswith("-"):
+                # This was probably a misspelled stage name
+                message = message + (
+                    f". If `{unrecognized}` was intended to invoke "
+                    "a stage, please run `turnkey -h` and check the spelling and availability of that "
+                    "stage."
+                )
+        self.print_usage()
+        printing.log_error(message)
+        self.exit(2)
+
+
 class Stage(abc.ABC):
 
     unique_name: str
+
+    @classmethod
+    def helpful_parser(cls, description: str, **kwargs):
+        epilog = (
+            f"`{cls.unique_name}` is a Stage. It is intended to be invoked as "
+            "part of a sequence of Stages, for example: `turnkey -i INPUTS stage-one "
+            "stage-two stage-three`"
+        )
+
+        return StageParser(
+            prog=f"turnkey {cls.unique_name}",
+            description=description,
+            epilog=epilog,
+            **kwargs,
+        )
 
     def status_line(self, successful, verbosity):
         """

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -241,7 +241,7 @@ Management tool choices:
             if cmd[0] in stages_invoked.keys():
                 parser.error(
                     "A single call to turnkey can only invoke each stage once, "
-                    f"however this call invokes stage {cmd[0]} twice."
+                    f"however this call invokes stage {cmd[0]} multiple times."
                 )
             current_stage = cmd.pop(0)
             stages_invoked[current_stage] = []

--- a/src/turnkeyml/cli/cli.py
+++ b/src/turnkeyml/cli/cli.py
@@ -69,7 +69,7 @@ def _check_extension(
             # Mispelled stage names can be picked up as input files, so we check
             # for this case here and try to provide a better suggestion
             error_func(
-                f"unrecognized argument {file_name}, did you mean {close_matches[0]}?"
+                f"unrecognized argument '{file_name}', did you mean '{close_matches[0]}'?"
             )
         else:
             error_func(

--- a/src/turnkeyml/run/benchmark_model.py
+++ b/src/turnkeyml/run/benchmark_model.py
@@ -34,7 +34,7 @@ class Benchmark(stage.Stage):
 
     @staticmethod
     def parser(add_help: bool = True) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+        parser = __class__.helpful_parser(
             description="Benchmark a model",
             add_help=add_help,
         )


### PR DESCRIPTION
Closes #176, #175, aspects of #168

Prior to this PR, there were few guardrails on the CLI and an incorrect usage would result in a confusing error message. 

After this PR, the following cases have been resolved:
- Breaking the CLI rules (e.g., no stages, duplicate stages) no longer prints a stack trace
- Incorrect arguments to a stage will now show `usage: turnkey STAGE [-h]` in the usage instead of just `usage: turnkey [-h]`
- Invalid stage names no longer throw an ambiguous "unrecognized arguments" error
- Running `turnkey` by itself (no args) no longer silently exits

This is accomplished through two custom ArgumentParser classes:
- Custom top-level CLI parser
- `stage.StageParser`, which is exposed through `__class__.helpful_parser()`.
  - All Stages should make use of this instead of the standard `argparse.ArgumentParser`, however if this feature is neglected then the Stages will simply use the original less helpful ArgumentParser.