### PR TITLE
Consistent naming scheme for stages

### DIFF
--- a/.github/workflows/test_turnkey.yml
+++ b/.github/workflows/test_turnkey.yml
@@ -62,7 +62,7 @@ jobs:
           rm -rf ~/.cache/turnkey
           turnkey -i examples/cli/scripts/two_models.py discover export-pytorch benchmark
           rm -rf ~/.cache/turnkey
-          turnkey -i examples/cli/onnx/hello_world.onnx onnx-load benchmark
+          turnkey -i examples/cli/onnx/hello_world.onnx load-onnx benchmark
 
           # E2E tests
           cd test/

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -27,6 +27,34 @@ TurnkeyML supports a variety of built-in build sequences, runtimes, and devices 
 
 A turnkey plugin is a pip-installable package that implements support for building a model using a custom sequence and/or benchmarking a model on a [device](https://github.com/onnx/turnkeyml/blob/main/docs/tools_user_guide.md#device) with a [runtime](https://github.com/onnx/turnkeyml/blob/main/docs/tools_user_guide.md#runtime). These packages must adhere to a specific interface that is documented below. 
 
+### Naming Scheme
+
+Plugins should be named in a way that makes it easy to refer to them in a sentence. 
+
+General rules:
+
+- The word "onnx" should be assumed wherever possible since this is an ONNX toolchain
+- Name the tool as a verb that references the action it is taking
+- Avoid using prepositions like "to"
+
+Examples:
+
+- Anything that loads anything starts with `load-`
+  - `load-build`
+  - `load-onnx` (formerly `onnx-load`)
+  - `load-llm-checkpoint`
+- Anything that exports to ONNX should start with `export-SOURCE` since the "onnx" part is assumed
+  - `export-pytorch` 
+- ONNX-to-ONNX transformations should have the form `ACTION[-RESULT]` where `RESULT` optionally adds necessary detail to the action
+  - `optimize-ort` (formerly `optimize-onnx`), where the action is short for "optimize-with-onnxruntime"
+  - `convert-fp16`
+  - `quantize-int8`
+- `discover`, `benchmark`: good single-word verbs
+- Compilation should use `compile-TARGET`, like `compile-ryzen-npu`
+
+This allows for sequences-as-sentences like the following (with prepositions assumed):
+- `discover` then `export-[to-]pytorch[-to-onnx]` then `optimize-[with-]ort` then `quantize-[to-]int8` then `compile-[for-]ryzen-npu`
+
 ### Plugin Directory Layout
 
 A plugin package that instantiates all of the optional files would have this directory layout:

--- a/examples/build_api/hello_onnx_world.py
+++ b/examples/build_api/hello_onnx_world.py
@@ -14,7 +14,7 @@ import os
 import torch
 from turnkeyml import build_model
 from turnkeyml.build.stage import Sequence
-from turnkeyml.build.export import OnnxLoad
+from turnkeyml.build.export import LoadOnnx
 
 torch.manual_seed(0)
 
@@ -58,7 +58,7 @@ def to_numpy(tensor):
 
 
 # Build the model
-sequence = Sequence(stages={OnnxLoad(): ["--input", onnx_model]})
+sequence = Sequence(stages={LoadOnnx(): ["--input", onnx_model]})
 state = build_model(
     sequence=sequence,
     model=onnx_model,

--- a/src/turnkeyml/build/export.py
+++ b/src/turnkeyml/build/export.py
@@ -81,7 +81,7 @@ def converted_onnx_file(state: fs.State):
     )
 
 
-class OnnxLoad(stage.Stage):
+class LoadOnnx(stage.Stage):
     """
     Stage that takes an ONNX model as input and passes it to the following
     stages.
@@ -93,7 +93,7 @@ class OnnxLoad(stage.Stage):
      - state.inputs are valid inputs to that ONNX file
     """
 
-    unique_name = "onnx-load"
+    unique_name = "load-onnx"
 
     def __init__(self):
         super().__init__(monitor_message="Loading ONNX Model")
@@ -372,7 +372,7 @@ class VerifyOnnxExporter(stage.Stage):
     Note that the derived ONNX file is discarded by the verification API,
     so we can't use it in downstream Stages. To use this stage inline with
     other build stages, we recommend:
-        discover -> verify-onnx-exporter -> export-pytorch -> other stages
+        discover -> verify-exporter -> export-pytorch -> other stages
 
     Expected inputs:
      - state.model is a torch.nn.Module or torch.jit.ScriptModule
@@ -382,7 +382,7 @@ class VerifyOnnxExporter(stage.Stage):
     Outputs: No change to state
     """
 
-    unique_name = "verify-onnx-exporter"
+    unique_name = "verify-exporter"
 
     def __init__(self):
         super().__init__(monitor_message="Verifying ONNX exporter")
@@ -454,7 +454,7 @@ class OptimizeOnnxModel(stage.Stage):
      - A *-opt.onnx file
     """
 
-    unique_name = "optimize-onnx"
+    unique_name = "optimize-ort"
 
     def __init__(self):
         super().__init__(monitor_message="Optimizing ONNX file")
@@ -524,7 +524,7 @@ class ConvertOnnxToFp16(stage.Stage):
      - A *-f16.onnx file with FP16 trained parameters
     """
 
-    unique_name = "fp16-conversion"
+    unique_name = "convert-fp16"
 
     def __init__(self):
         super().__init__(

--- a/src/turnkeyml/build/stage_plugins.py
+++ b/src/turnkeyml/build/stage_plugins.py
@@ -20,7 +20,7 @@ SUPPORTED_STAGES = [
     Discover,
     export.ExportPytorchModel,
     export.OptimizeOnnxModel,
-    export.OnnxLoad,
+    export.LoadOnnx,
     export.ConvertOnnxToFp16,
     export.VerifyOnnxExporter,
 ]

--- a/test/build_model.py
+++ b/test/build_model.py
@@ -51,7 +51,7 @@ def basic_pytorch_sequence():
 
 
 def basic_onnx_sequence(input: str):
-    return stage.Sequence(stages={export.OnnxLoad(): ["--input", input]})
+    return stage.Sequence(stages={export.LoadOnnx(): ["--input", input]})
 
 
 # Run build_model() and get results

--- a/test/cli.py
+++ b/test/cli.py
@@ -139,7 +139,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -159,7 +159,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -181,7 +181,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -202,7 +202,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -239,7 +239,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -304,7 +304,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -401,7 +401,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -422,7 +422,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
@@ -445,7 +445,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
@@ -479,7 +479,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -496,7 +496,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
             "--device",
             "reimplement_me",
@@ -544,7 +544,7 @@ class Testing(unittest.TestCase):
                 cache_dir,
                 "discover",
                 "export-pytorch",
-                "optimize-onnx",
+                "optimize-ort",
                 "benchmark",
                 "--device",
                 "x86",
@@ -580,7 +580,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
             "--device",
             "x86",
@@ -609,7 +609,7 @@ class Testing(unittest.TestCase):
             "export-pytorch",
             "--opset",
             str(user_opset),
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
@@ -632,7 +632,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
             "--iterations",
             str(test_iterations),
@@ -662,7 +662,7 @@ class Testing(unittest.TestCase):
                 "--process-isolation",
                 "discover",
                 "export-pytorch",
-                "optimize-onnx",
+                "optimize-ort",
                 "benchmark",
             ]
             with patch.object(sys, "argv", testargs):
@@ -685,7 +685,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
@@ -706,7 +706,7 @@ class Testing(unittest.TestCase):
                 "gobbledegook",
                 "discover",
                 "export-pytorch",
-                "optimize-onnx",
+                "optimize-ort",
                 "benchmark",
             ]
             with patch.object(sys, "argv", flatten(testargs)):
@@ -754,7 +754,7 @@ class Testing(unittest.TestCase):
             onnx_file,
             "--cache-dir",
             cache_dir,
-            "onnx-load",
+            "load-onnx",
             "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
@@ -789,7 +789,7 @@ class Testing(unittest.TestCase):
             onnx_file,
             "--cache-dir",
             cache_dir,
-            "onnx-load",
+            "load-onnx",
             "benchmark",
         ]
         with patch.object(sys, "argv", testargs):
@@ -820,7 +820,7 @@ class Testing(unittest.TestCase):
                     filename,
                     "discover",
                     "export-pytorch",
-                    "optimize-onnx",
+                    "optimize-ort",
                     "benchmark",
                 ]
                 with patch.object(sys, "argv", testargs):
@@ -837,7 +837,7 @@ class Testing(unittest.TestCase):
                     file_prefix,
                     "discover",
                     "export-pytorch",
-                    "optimize-onnx",
+                    "optimize-ort",
                     "benchmark",
                 ]
                 with patch.object(sys, "argv", testargs):
@@ -856,7 +856,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()
@@ -889,7 +889,7 @@ class Testing(unittest.TestCase):
             "10",
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
@@ -938,7 +938,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
@@ -1012,15 +1012,15 @@ class Testing(unittest.TestCase):
                 "selected_sequence_of_stages",
                 "stage_duration:discover",
                 "stage_duration:export-pytorch",
-                "stage_duration:optimize-onnx",
+                "stage_duration:optimize-ort",
                 "stage_status:discover",
                 "stage_status:export-pytorch",
-                "stage_status:optimize-onnx",
+                "stage_status:optimize-ort",
             ],
         )
         for result in result_dict.values():
             # All of the models should have exported to ONNX and optimized the ONNX model
-            for stage in ["export-pytorch", "optimize-onnx"]:
+            for stage in ["export-pytorch", "optimize-ort"]:
                 assert stage in result["selected_sequence_of_stages"]
                 duration = result[f"stage_duration:{stage}"]
                 status = result[f"stage_status:{stage}"]
@@ -1048,7 +1048,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             turnkeycli()
@@ -1095,9 +1095,29 @@ class Testing(unittest.TestCase):
             "--cache-dir",
             cache_dir,
             "discover",
-            "verify-onnx-exporter",
+            "verify-exporter",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
+        ]
+        with patch.object(sys, "argv", testargs):
+            turnkeycli()
+
+        assert_success_of_builds([test_script], cache_dir)
+
+    def test_029_cli_fp16_convert(self):
+        # Test the first model in the corpus
+        test_script = list(common.test_scripts_dot_py.keys())[0]
+
+        testargs = [
+            "turnkey",
+            "-i",
+            os.path.join(corpus_dir, test_script),
+            "--cache-dir",
+            cache_dir,
+            "discover",
+            "export-pytorch",
+            "optimize-ort",
+            "convert-fp16",
         ]
         with patch.object(sys, "argv", testargs):
             turnkeycli()

--- a/test/plugins.py
+++ b/test/plugins.py
@@ -31,7 +31,7 @@ class Testing(unittest.TestCase):
             cache_dir,
             "discover",
             "export-pytorch",
-            "optimize-onnx",
+            "optimize-ort",
             "benchmark",
             "--device",
             "example_family",


### PR DESCRIPTION
Closes #180 

Long PR that implements very few real changes:

- Added the stage naming scheme to the contribution docs (NOTE: does not update the rest of that doc, doc updates are out of scope for this PR)
- `onnx-load` renamed to `load-onnx`
- `optimize-onnx` renamed to `optimize-ort`
- `fp16-conversion` renamed to `convert-fp16`
  - Added a test for `convert-fp16` since I realized it was untested
-  `verify-onnx-exporter` renamed to `verify-exporter`