### PR TITLE
Prevent onnx 1.16.2 from being deployed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
     ],
     install_requires=[
         "invoke>=2.0.0",
-        "onnx>=1.11.0",
+        # 1.16.2 causes a crash:
+        #   ImportError: DLL load failed while importing onnx_cpp2py_export
+        "onnx>=1.11.0,<1.16.2",
         "onnxmltools==1.10.0",
         "onnxruntime >=1.10.1",
         "torch>=1.12.1",
@@ -45,9 +47,6 @@ setup(
         "pandas>=1.5.3",
         "fasteners",
         "GitPython>=3.1.40",
-        # Necessary until upstream packages account for the breaking
-        # change to numpy
-        "numpy<2.0.0",
         "psutil",
     ],
     classifiers=[],


### PR DESCRIPTION
onnx=1.16.2 came out this morning and breaks our CI with the following error:

```
(tkml) PS C:\work\turnkeyml> turnkey -h 
Traceback (most recent call last):
  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tkml\lib\runpy.py", line 194, in _run_module_as_main  
    return _run_code(code, main_globals, None,
  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tkml\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tkml\Scripts\turnkey.exe\__main__.py", line 4, in <module>
  File "C:\work\turnkeyml\src\turnkeyml\__init__.py", line 3, in <module>
    from .files_api import evaluate_files
  File "C:\work\turnkeyml\src\turnkeyml\files_api.py", line 8, in <module>
    from turnkeyml.sequence import Sequence
  File "C:\work\turnkeyml\src\turnkeyml\sequence\__init__.py", line 1, in <module>
    from .sequence import Sequence
  File "C:\work\turnkeyml\src\turnkeyml\sequence\sequence.py", line 11, in <module>
    import turnkeyml.common.status as status
  File "C:\work\turnkeyml\src\turnkeyml\common\status.py", line 10, in <module>
    import turnkeyml.common.analyze_model as analyze_model
  File "C:\work\turnkeyml\src\turnkeyml\common\analyze_model.py", line 4, in <module>
    import onnx
  File "C:\Users\jefowers\AppData\Local\miniconda3\envs\tkml\lib\site-packages\onnx\__init__.py", line 77, in <module>
    from onnx.onnx_cpp2py_export import ONNX_ML
ImportError: DLL load failed while importing onnx_cpp2py_export: A dynamic link library (DLL) initialization routine failed.
```

This PR prevents that specific onnx package from being deployed.